### PR TITLE
[8.0][FIX] product_multi_company: Fix hook on deactivated records

### DIFF
--- a/product_multi_company/README.rst
+++ b/product_multi_company/README.rst
@@ -47,6 +47,7 @@ Contributors
 ------------
 
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/product_multi_company/__openerp__.py
+++ b/product_multi_company/__openerp__.py
@@ -9,7 +9,7 @@
               "Odoo Community Association (OCA)",
     'website': "http://serviciosbaeza.com",
     'category': 'Product Management',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.1',
     'license': 'AGPL-3',
     'depends': [
         'product',

--- a/product_multi_company/hooks.py
+++ b/product_multi_company/hooks.py
@@ -16,7 +16,9 @@ def post_init_hook(cr, registry):
                              "('company_ids', 'in', user.company_id.id), "
                              "('company_id', '=', False)]")
         # Copy company values
-        template_model = env['product.template']
+        template_model = env['product.template'].with_context(
+            active_test=False,
+        )
         groups = template_model.read_group([], ['company_id'], ['company_id'])
         for group in groups:
             if not group['company_id']:

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -2,6 +2,8 @@
 # (c) 2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from ..hooks import post_init_hook
+
 from openerp.tests import common
 from openerp.osv.osv import except_orm as AccessError
 
@@ -77,3 +79,9 @@ class TestProductMultiCompany(common.TransactionCase):
         domain = (" ['|',('company_id','=',user.company_id.id),"
                   "('company_id','=',False)]")
         self.assertEqual(rule.domain_force, domain)
+
+    def test_init_hook(self):
+        deactivated_product = self.env.ref('product.product_product_4d')
+        self.assertFalse(deactivated_product.active)
+        self.assertEqual(deactivated_product.company_ids.ids,
+                         deactivated_product.company_id.ids)


### PR DESCRIPTION
* Add domain to include both active and inactive records into the install hook

Re #48 

Same note from #49 - I'm having a bit of trouble figuring out how to actually test this. Is there a way to insert/change a record in the db before the module install?