### PR TITLE
[9.0][FIX] partner_multi_company: Fix hook on deactivated partners

### DIFF
--- a/partner_multi_company/README.rst
+++ b/partner_multi_company/README.rst
@@ -52,6 +52,7 @@ Contributors
 
 * Oihane Crucelaegui <oihanecruce@gmail.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/partner_multi_company/__openerp__.py
+++ b/partner_multi_company/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Partner multi-company",
     "summary": "Select individually the partner visibility on each company",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "license": "AGPL-3",
     "depends": [
         "base_suspend_security",

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -21,7 +21,7 @@ def post_init_hook(cr, registry):
             ),
         })
         # Copy company values
-        partner_model = env['res.partner']
+        partner_model = env['res.partner'].with_context(active_test=False)
         groups = partner_model.read_group([], ['company_id'], ['company_id'])
         for group in groups:
             if group['company_id']:

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -117,3 +117,9 @@ class TestPartnerMultiCompany(common.SavepointCase):
         self.user_company_1.company_id = self.company_2.id
         self.assertEqual(
             self.user_company_1.partner_id.company_id, self.company_2)
+
+    def test_init_hook(self):
+        """It should set company_ids even on deactivated partner."""
+        deactivated_partner = self.env.ref('base.res_partner_20')
+        self.assertEqual(deactivated_partner.company_ids.ids,
+                         deactivated_partner.company_id.ids)


### PR DESCRIPTION
* Add domain to include both active and inactive partners into the install hook

Re #48