### PR TITLE
8.0 WIP ADD complete_company_creation

### DIFF
--- a/complete_company_creation/README.rst
+++ b/complete_company_creation/README.rst
@@ -1,0 +1,70 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Complete Company Creation
+=========================
+
+This module add hooks to complete the creation of a company according to installed modules.
+
+The default company (main_company) include xml data on different models.
+
+The purpose of this module is to propose to duplicate these data
+for the new company.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+.. figure:: path/to/local/image.png
+   :alt: alternative description
+   :width: 600 px
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/133/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/muti-company/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* David BEAL <david.beal@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/complete_company_creation/__init__.py
+++ b/complete_company_creation/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/complete_company_creation/__openerp__.py
+++ b/complete_company_creation/__openerp__.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+# © 2017 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Complete Company Creation',
+    'summary': "Add default data for your new company",
+    'version': '8.0.0.0.1',
+    'author': 'Akretion',
+    'website': 'www.akretion.com',
+    'license': 'AGPL-3',
+    'category': 'Tools',
+    'depends': [
+        'base',
+    ],
+    'data': [
+    ],
+    'installable': True,
+}

--- a/complete_company_creation/models/__init__.py
+++ b/complete_company_creation/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_company

--- a/complete_company_creation/models/res_company.py
+++ b/complete_company_creation/models/res_company.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+# © 2017 David BEAL @ Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from openerp import api, fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def create(self, vals):
+        res = super(ResCompany, self).create(vals)
+        self._prepare_company_creation()
+        return res
+
+    def _prepare_company_creation(self):
+        """ This method will be called """
+        res = super(ResCompany, self)._prepare_company_creation()


### PR DESCRIPTION
This module add hooks to complete the creation of a company according to installed modules.

The default company (main_company) include xml data on different models.

The purpose of this module is to propose to duplicate these data for the new company.