### PR TITLE
[10.0][add] mcfix_base

### DIFF
--- a/mcfix_base/README.rst
+++ b/mcfix_base/README.rst
@@ -1,0 +1,79 @@
+.. image:: https://img.shields.io/badge/licence-lgpl--3-blue.svg
+   :target: http://www.gnu.org/licenses/LGPL-3.0-standalone.html
+   :alt: License: LGPL-3
+
+==========
+Mcfix Base
+==========
+
+This module is part of a set of modules that are intended to make sure that
+the multi-company functionality is consistent.
+
+It adds a computed field `current_company_id` to the `res.partner`, so that
+property fields associated to this model, defined in other modules, will only
+allow users to select values that are consistent with the company that the
+user is currently working on.
+
+
+Installation
+============
+
+To install this module, simply follow the standard install process.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/multi-company/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Usage
+=====
+
+Todo
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/133/10.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/multi-company/issues>`_.
+In case of trouble, please check there if your issue has already been reported. 
+If you spotted it first, help us smash it by providing detailed and welcomed 
+feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: 
+  `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Enric Tobella <etobella@creublanca.es>
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mcfix_base/__init__.py
+++ b/mcfix_base/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/mcfix_base/__manifest__.py
+++ b/mcfix_base/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+{
+    'name': 'Mcfix Base',
+    'version': '10.0.1.0.0',
+    'summary': 'Provides a base fix for multi-company management',
+    'author': 'Creu Blanca,'
+              'Odoo Community Association (OCA)',
+    'category': 'base',
+    'website': 'https://github.com/OCA/multi-company',
+    'depends': ['base'],
+    'data': [
+        'views/res_partner.xml'
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/mcfix_base/models/__init__.py
+++ b/mcfix_base/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import res_partner

--- a/mcfix_base/models/res_partner.py
+++ b/mcfix_base/models/res_partner.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.one
+    def _compute_current_company_id(self):
+        self.current_company_id = self.env['res.company'].browse(
+            self._context.get('force_company') or
+            self.env.user.company_id.id).ensure_one()
+
+    current_company_id = fields.Many2one(
+        comodel_name='res.company',
+        default=_compute_current_company_id,
+        compute='_compute_current_company_id',
+        store=False
+    )

--- a/mcfix_base/views/res_partner.xml
+++ b/mcfix_base/views/res_partner.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="current_company_id" invisible="1"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Mcfix Base
==========

This module is part of a set of modules that are intended to make sure that
the multi-company functionality is consistent.

It adds a computed field `current_company_id` to the `res.partner`, so that
property fields associated to this model, defined in other modules, will only
allow users to select values that are consistent with the company that the
user is currently working on.