### PR TITLE
[10.0] [add] mcfix_product

### DIFF
--- a/mcfix_product/README.rst
+++ b/mcfix_product/README.rst
@@ -1,0 +1,73 @@
+.. image:: https://img.shields.io/badge/licence-lgpl--3-blue.svg
+   :target: http://www.gnu.org/licenses/LGPL-3.0-standalone.html
+   :alt: License: LGPL-3
+
+=============
+Mcfix Product
+=============
+
+This module is part of a set of modules that are intended to make sure that
+the multi-company functionality is consistent.
+
+It adds a computed field `current_company_id` to the `product.product` and
+`product.template`, so that property fields associated to these models, defined
+in other modules, will only allow users to select values that are consistent
+with the company that the user is currently working on.
+
+It also adds constraints to ensure consistency company-wise:
+
+* Supplier Info must belong to the same company as the product's and the
+  supplier's.
+
+
+Installation
+============
+
+To install this module, simply follow the standard install process.
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/133/10.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/multi-company/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smash it by providing detailed and welcomed
+feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association:
+  `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Enric Tobella <etobella@creublanca.es>
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mcfix_product/__init__.py
+++ b/mcfix_product/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import models

--- a/mcfix_product/__manifest__.py
+++ b/mcfix_product/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+{
+    'name': 'Mcfix Product',
+    'version': '10.0.1.0.0',
+    'summary': 'Provides product fixes for multi-company management',
+    'author': 'Creu Blanca,'
+              'Eficent,'
+              'Odoo Community Association (OCA)',
+    'category': 'base',
+    'website': 'https://github.com/OCA/multi-company',
+    'license': 'LGPL-3',
+    'depends': ['product'],
+    'data': [
+        'views/product_views.xml',
+        'views/product_supplierinfo_views.xml'
+    ],
+    'installable': True,
+    'application': False,
+    'auto_install': True,
+}

--- a/mcfix_product/models/__init__.py
+++ b/mcfix_product/models/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import product_category
+from . import product_template
+from . import product_supplierinfo

--- a/mcfix_product/models/product_category.py
+++ b/mcfix_product/models/product_category.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    @api.multi
+    def _compute_current_company_id(self):
+        for category in self:
+            category.current_company_id = self.env['res.company'].browse(
+                category._context.get('force_company') or
+                category.env.user.company_id.id).ensure_one()
+
+    current_company_id = fields.Many2one(
+        comodel_name='res.company',
+        default=_compute_current_company_id,
+        compute='_compute_current_company_id',
+        store=False
+    )

--- a/mcfix_product/models/product_supplierinfo.py
+++ b/mcfix_product/models/product_supplierinfo.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class ProductSupplierInfo(models.Model):
+    _inherit = 'product.supplierinfo'
+
+    @api.constrains('company_id', 'product_id')
+    def _check_company_product(self):
+        if self.product_id.company_id and self.product_id.company_id != \
+                self.company_id:
+            raise ValidationError(_(
+                'Company %s defined in the product does not match '
+                'with that defined in the supplier info record %s') % (
+                    self.product_id.name, self.name))
+
+    @api.constrains('company_id', 'name')
+    def _check_company_partner(self):
+        if self.name.company_id and self.name.company_id != \
+                self.company_id:
+            raise ValidationError(_(
+                'Company %s defined in the supplier does not match '
+                'with that defined in the supplier info record.') %
+                self.product_id.name)
+
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        if self.name.company_id and self.name.company_id != self.company_id:
+            self.name = False
+        if self.product_id.company_id and self.product_id.company_id != \
+                self.company_id:
+            self.product_id = False

--- a/mcfix_product/models/product_template.py
+++ b/mcfix_product/models/product_template.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models, api, fields, _
+from odoo.exceptions import ValidationError
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.multi
+    def _compute_current_company_id(self):
+        for pt in self:
+            pt.current_company_id = self.env['res.company'].browse(
+                pt._context.get('force_company') or
+                pt.env.user.company_id.id).ensure_one()
+
+    current_company_id = fields.Many2one(
+        comodel_name='res.company',
+        default=_compute_current_company_id,
+        compute='_compute_current_company_id',
+        store=False
+    )
+
+    @api.constrains('company_id', 'seller_ids')
+    def _check_company_seller(self):
+        for seller in self.seller_ids:
+            if self.company_id and seller.company_id != self.company_id:
+                raise ValidationError(_(
+                    'Company %s defined in the product does not match '
+                    'with that defined in the supplier info record %s') % (
+                        self.company_id.name, seller.name))

--- a/mcfix_product/tests/__init__.py
+++ b/mcfix_product/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import test_mcfix_product

--- a/mcfix_product/tests/test_mcfix_product.py
+++ b/mcfix_product/tests/test_mcfix_product.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Creu Blanca.
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tests import common
+from odoo import exceptions
+
+
+class TestMcfixProduct(common.TransactionCase):
+
+    def setUp(self):
+        super(TestMcfixProduct, self).setUp()
+        self.res_users_model = self.env['res.users']
+        self.group_user = self.env.ref('base.group_user')
+        self.company_1 = self.env['res.company'].create(
+            {'name': 'Test company 1'}
+        )
+        self.company_2 = self.env['res.company'].create(
+            {'name': 'Test company 2'}
+        )
+
+        self.partner_1 = self.env['res.partner'].create({
+            'name': 'Supplier',
+            'supplier': True,
+            'company_id': self.company_1.id
+        })
+
+        # Create user_1
+        self.user_1 =\
+            self.res_users_model.with_context({'no_reset_password': True}).\
+            create({
+                'name': 'Test User',
+                'login': 'user_1',
+                'password': 'demo',
+                'email': 'example@yourcompany.com',
+                'company_id': self.company_1.id,
+                'company_ids': [(4, self.company_1.id),
+                                (4, self.company_2.id)],
+                'groups_id': [(6, 0, [self.group_user.id])]
+            })
+
+    def test_product_category(self):
+        product_category = self.env['product.category'].create(
+            {'name': 'Test'})
+        self.assertEquals(product_category.sudo(
+            self.user_1).current_company_id, self.user_1.company_id)
+        self.assertEquals(product_category.sudo(
+            self.user_1).with_context(
+            force_company=self.company_2.id).current_company_id, self.company_2)
+
+    def test_product_template(self):
+        product_template = self.env['product.template'].create(
+            {'name': 'Test'})
+        self.assertEquals(product_template.sudo(
+            self.user_1).current_company_id, self.user_1.company_id)
+        self.assertEquals(product_template.sudo(
+            self.user_1).with_context(
+            force_company=self.company_2.id).current_company_id, self.company_2)
+
+    def test_product_supplierinfo_1(self):
+        product_product = self.env['product.product'].create(
+            {'name': 'Test',
+             'company_id': self.company_1.id})
+        with self.assertRaises(exceptions.ValidationError):
+            self.env['product.supplierinfo'].create(
+                {'product_id': product_product.id,
+                 'name': self.partner_1.id,
+                 'company_id': self.company_2.id})
+
+    def test_product_supplierinfo_2(self):
+        product_product = self.env['product.product'].create(
+            {'name': 'Test',
+             'company_id': self.company_1.id})
+        self.partner_1.company_id = self.company_2
+        with self.assertRaises(exceptions.ValidationError):
+            self.env['product.supplierinfo'].create(
+                {'product_id': product_product.id,
+                 'name': self.partner_1.id,
+                 'company_id': self.company_1.id})

--- a/mcfix_product/views/product_supplierinfo_views.xml
+++ b/mcfix_product/views/product_supplierinfo_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_supplierinfo_form_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.form.view</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_form_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="attributes">
+                <attribute name="domain">['|', ('company_id', '=', company_id), ('company_id', '=', False)]</attribute>
+            </field>
+            <field name="product_id" position="attributes">
+                <attribute name="domain">[('product_tmpl_id', '=', product_tmpl_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/mcfix_product/views/product_views.xml
+++ b/mcfix_product/views/product_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.account.purchase.ok.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="current_company_id" invisible="1"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="product_category_form_view" model="ir.ui.view">
+        <field name="name">product.category.form</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="current_company_id" invisible="1"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Mcfix Product
=============

This module is part of a set of modules that are intended to make sure that
the multi-company functionality is consistent.

It adds a computed field `current_company_id` to the `product.product` and
`product.template`, so that property fields associated to these models, defined
in other modules, will only allow users to select values that are consistent
with the company that the user is currently working on.

It also adds constraints to ensure consistency company-wise:

* Supplier Info must belong to the same company as the product's and the
supplier's.
