### PR TITLE
[FIX] user should be able to create in company assignment model

### DIFF
--- a/base_multi_company/security/ir.model.access.csv
+++ b/base_multi_company/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_res_company_assignment_group_erp_manager,res_company_assignment group_erp_manager,model_res_company_assignment,base.group_erp_manager,1,1,1,1
-access_res_company_assignment_group_user,res_company_assignment group_user,model_res_company_assignment,base.group_user,1,0,0,0
+access_res_company_assignment_group_user,res_company_assignment group_user,model_res_company_assignment,base.group_user,1,0,1,0


### PR DESCRIPTION
This is needed otherwise you won't be able to create a record on the model inherited.

For example, I have a sale manager which is not able to create a product.

He has the right to create on product.template but not on ResCompanyAssignment.