### PR TITLE
[8.0] purchase_sale_inter_company: fix and extract the search domain of users from the _check_intercompany_product method 

### DIFF
--- a/purchase_sale_inter_company/i18n/fr.po
+++ b/purchase_sale_inter_company/i18n/fr.po
@@ -134,3 +134,8 @@ msgstr "Vous ne pouvez pas créer la SO à partir de la PO car la devise sur la 
 msgid "{'invisible':['|', ('invoice_method','in', ['picking', 'manual', 'intercompany']), '|', ('state','!=', 'approved'), ('invoiced','=',True)]}"
 msgstr "{'invisible':['|', ('invoice_method','in', ['picking', 'manual', 'intercompany']), '|', ('state','!=', 'approved'), ('invoiced','=',True)]}"
 
+#. module: purchase
+#: selection:purchase.order,invoice_method:0
+msgid "Based on intercompany invoice"
+msgstr "Basé sur la facture inter-société"
+


### PR DESCRIPTION
- Extract the search domain of the users from the _check_intercompany_product method to facilitate overloading
- Fix the search domain of the users to ensure that the user with whom the product is tested will have the necessary rights on 'purchase.order.line'
- Add the field 'note' in the list of fields to be sent to the sales order
- Fix french translate