### PR TITLE
Fix/partner multicompany

### DIFF
--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -39,6 +39,7 @@ class ResPartner(models.Model):
         return vals
 
     @api.model
+    @api.returns('self', lambda value: value.id)
     def create(self, vals):
         """Neutralize the default value applied to company_id that can't be
         removed in the inheritance, and that will activate the inverse method,
@@ -48,7 +49,10 @@ class ResPartner(models.Model):
         # We must suspend security during this creation because it fails due to
         # all the mail stuff in between that confuses security rules
         obj = getattr(self, 'suspend_security', lambda: self)()
-        return super(ResPartner, obj).create(vals)
+        new_record = super(ResPartner, obj).create(vals)
+        # Call check_access_rules on new record to honor security rules
+        self.browse(new_record.id).check_access_rule('create')
+        return new_record
 
     @api.multi
     @api.depends('company_ids')

--- a/partner_multi_company/models/res_users.py
+++ b/partner_multi_company/models/res_users.py
@@ -14,7 +14,7 @@ class ResUsers(models.Model):
         if 'company_ids' in vals:
             res.partner_id.company_ids = vals['company_ids']
         if 'company_id' in vals:
-            res.partner_id.company_ids = [(6, 0, [vals['company_id']])]
+            res.partner_id.company_ids = [(4, vals['company_id'])]
         return res
 
     @api.multi
@@ -22,5 +22,5 @@ class ResUsers(models.Model):
         res = super(ResUsers, self).write(vals)
         if 'company_id' in vals:
             for user in self.sudo():
-                user.partner_id.company_ids = [(6, 0, [vals['company_id']])]
+                user.partner_id.company_ids = [(4, vals['company_id'])]
         return res


### PR DESCRIPTION
This PR include two commits that fix some miss behaviours that we notice on a recent implementation. Both issues are present for module on all versions but as currently we are using 8.0 for this customer I'm sending this PR against 8.0 and later when approved will push from other versions.

First commit is for solve error reported on issue #72. 

Second commit is for allow to create a new res.partner but enforcing any security rule that have being added on database. The exactly user case that we are solving is for a customer that want to stop most of the users to be able to create res.partner records with `is_company` field set on `True`