### PR TITLE
[FIX][10.0][multi_company_abstract] Fix company_id computation issue (+ add unit test)

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -33,7 +33,13 @@ class MultiCompanyAbstract(models.AbstractModel):
 
     @api.multi
     def _compute_company_id(self):
+        user_company = self.env.user.company_id
         for record in self:
+            # Give the priority of the current company of the user to avoid
+            # access right error
+            if user_company.id in record.company_ids.ids:
+                record.company_id = user_company.id
+                continue
             for company in record.company_ids:
                 if company.id in self.env.user.company_ids.ids:
                     record.company_id = company.id


### PR DESCRIPTION
**Steps to reproduce (actual) error:**
- Configuration: `product.template` inherit `multi.company.abstract`
- Log in (not with Admin) with a user set with at least 2 `company_ids`
- Browse a product with at least 2 `company_ids`
- Check the `company_id` of the product
- If the `company_id` of the product is the same than the current company, stay on the same product but switch your current company (top right button)
- The `company_id` of the product is not your actual company: you will have some issue (for example to use pricelist (price list set to `without_discount` as `discount_policy`) on `sale.order` because this model use the `product.company_id.currency_id` => BOOM, `AccessError` exception because you don't have rights to read another company than the current one).

**Fix (this MR):**
- To compute the `company_id` field of a `multi.company.abstract`, give the priority to the company of the current user. If this company is not into `company_ids` of the targeted model, pick the first company (actual behaviour)