### PR TITLE
[FIX] Compatibility with purchase_double_validation.

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -15,9 +15,9 @@ class PurchaseOrder(models.Model):
         selection_add=[('intercompany', 'Based on intercompany invoice')])
 
     @api.multi
-    def wkf_confirm_order(self):
+    def wkf_approve_order(self):
         """ Generate inter company sale order base on conditions."""
-        res = super(PurchaseOrder, self).wkf_confirm_order()
+        res = super(PurchaseOrder, self).wkf_approve_order()
         for purchase_order in self:
             # get the company from partner then trigger action of
             # intercompany relation


### PR DESCRIPTION
In this module, the order can be reopened after the order confirmation, which
leads to multiple intercompany sales orders for the same purchase order upon
reconfirmation.