### PR TITLE
[11.0][IMP] account_invoice_inter_company: option to avoid product_id in invoice lines

### DIFF
--- a/account_invoice_inter_company/README.rst
+++ b/account_invoice_inter_company/README.rst
@@ -30,6 +30,12 @@ If you choose the option *Invoice Auto Validation* in the configuration of compa
    :target: https://runbot.odoo-community.org/runbot/133/11.0
 
 
+Known issues / Roadmap
+======================
+
+ * Product mapping: would be nice to have a matrix with the products on the left side and on the top row the companies.
+
+
 Bug Tracker
 ===========
 

--- a/account_invoice_inter_company/__manifest__.py
+++ b/account_invoice_inter_company/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Inter Company Module for Invoices',
     'summary': 'Intercompany invoice rules',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.1.0',
     'category': 'Accounting & Finance',
     'website': 'https://github.com/OCA/multi-company',
     'author': 'Odoo SA, Akretion, Odoo Community Association (OCA)',

--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -43,6 +43,8 @@ class AccountInvoice(models.Model):
     @api.multi
     def _check_intercompany_product(self, dest_company):
         self.ensure_one()
+        if not dest_company.use_inter_company_products:
+            return
         domain = dest_company._get_user_domain()
         dest_user = self.env['res.users'].search(domain, limit=1)
         if dest_user:
@@ -250,6 +252,11 @@ class AccountInvoiceLine(models.Model):
                     % (self.env.ref('account.data_account_type_revenue').name,
                        dest_company.name, dest_company.id))
         tax_ids = dest_line_data.get('invoice_line_tax_ids', False)
+
+        product_id = False
+        if dest_company.use_inter_company_products:
+            product_id = self.product_id.id or False
+
         vals = {
             'name': self.name,
             # TODO: it's wrong to just copy the price_unit
@@ -258,7 +265,7 @@ class AccountInvoiceLine(models.Model):
             'price_unit': self.price_unit,
             'quantity': self.quantity,
             'discount': self.discount,
-            'product_id': self.product_id.id or False,
+            'product_id': product_id,
             'sequence': self.sequence,
             'invoice_line_tax_ids': tax_ids or [],
             # Analytic accounts are per company

--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -85,7 +85,8 @@ class AccountInvoice(models.Model):
         dest_invoice = self.create(dest_invoice_data)
         # create invoice lines
         for src_line in self.invoice_line_ids:
-            if not src_line.product_id:
+            if dest_company.use_inter_company_products and \
+                    not src_line.product_id:
                 raise UserError(_(
                     "The invoice line '%s' doesn't have a product. "
                     "All invoice lines should have a product for "

--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -252,11 +252,9 @@ class AccountInvoiceLine(models.Model):
                     % (self.env.ref('account.data_account_type_revenue').name,
                        dest_company.name, dest_company.id))
         tax_ids = dest_line_data.get('invoice_line_tax_ids', False)
-
         product_id = False
         if dest_company.use_inter_company_products:
             product_id = self.product_id.id or False
-
         vals = {
             'name': self.name,
             # TODO: it's wrong to just copy the price_unit

--- a/account_invoice_inter_company/models/res_company.py
+++ b/account_invoice_inter_company/models/res_company.py
@@ -11,6 +11,10 @@ class ResCompany(models.Model):
         help="When an invoice is created by a multi company rule "
              "for this company, it will automatically validate it",
         default=True)
+    use_inter_company_products = fields.Boolean(
+        help="Use the same products when an invoice is created by "
+             "a multi company rule.",
+        default=True)
 
     @api.multi
     def _get_user_domain(self):

--- a/account_invoice_inter_company/models/res_config_settings.py
+++ b/account_invoice_inter_company/models/res_config_settings.py
@@ -12,3 +12,7 @@ class InterCompanyRulesConfig(models.TransientModel):
         string='Invoices Auto Validation',
         help='When an invoice is created by a multi company rule for '
              'this company, it will automatically validate it.')
+    use_inter_company_products = fields.Boolean(
+        related='company_id.use_inter_company_products',
+        help="Use the same products when an invoice is created by "
+             "a multi company rule.")

--- a/account_invoice_inter_company/views/res_config_settings_view.xml
+++ b/account_invoice_inter_company/views/res_config_settings_view.xml
@@ -17,6 +17,10 @@
                             <field name="invoice_auto_validation"/>
                             <label for="invoice_auto_validation"/>
                         </div>
+                        <div name="module_account_invoice_inter_company_use_inter_company_products">
+                            <field name="use_inter_company_products"/>
+                            <label for="use_inter_company_products"/>
+                        </div>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
For our multicompany environment we need an option to skip the product_id in the created invoice lines.
