### PR TITLE
[FIX] Property account selection during tests

### DIFF
--- a/account_invoice_inter_company/demo/inter_company_invoice.xml
+++ b/account_invoice_inter_company/demo/inter_company_invoice.xml
@@ -224,24 +224,28 @@
         <field name="fields_id" search="[('model','=','product.category'),('name','=','property_account_expense_categ')]"/>
         <field eval="'account.account,'+str(ref('a_expense_company_a'))" name="value"/>
         <field name="company_id" ref="company_a"/>
+        <field name="res_id" eval="'product.category,%s' % ref('product.product_category_all')"/>
     </record>
     <record id="property_account_income_categ_company_a" model="ir.property">
         <field name="name">property_account_income_categ_company_a</field>
         <field name="fields_id" search="[('model','=','product.category'),('name','=','property_account_income_categ')]"/>
         <field eval="'account.account,'+str(ref('a_sale_company_a'))" model="account.account" name="value"/>
         <field name="company_id" ref="company_a"/>
+        <field name="res_id" eval="'product.category,%s' % ref('product.product_category_all')"/>
     </record>
     <record id="property_account_expense_categ_company_b" model="ir.property">
         <field name="name">property_account_expense_categ_company_b</field>
         <field name="fields_id" search="[('model','=','product.category'),('name','=','property_account_expense_categ')]"/>
         <field eval="'account.account,'+str(ref('a_expense_company_b'))" name="value"/>
         <field name="company_id" ref="company_b"/>
+        <field name="res_id" eval="'product.category,%s' % ref('product.product_category_all')"/>
     </record>
     <record id="property_account_income_categ_company_b" model="ir.property">
         <field name="name">property_account_income_categ_company_b</field>
         <field name="fields_id" search="[('model','=','product.category'),('name','=','property_account_income_categ')]"/>
         <field eval="'account.account,'+str(ref('a_sale_company_b'))" model="account.account" name="value"/>
         <field name="company_id" ref="company_b"/>
+        <field name="res_id" eval="'product.category,%s' % ref('product.product_category_all')"/>
     </record>
 
     <!--


### PR DESCRIPTION
By adding revenue accounts and property defaults in demo data as well as
installing a chart of accounts when running tests, there are actually two
property defaults for the revenue and income accounts. One of each (those
from the chart of accounts) have a default tax set, which can cause a
difference in the total amounts of the source invoice and the destination
invoice preventing the destination invoice from being confirmed, failing
the tests.