### PR TITLE
[FIX][12.0]  stock_move_line_multi_company_security

### DIFF
--- a/stock_move_line_multi_company_security/security/stock_security.xml
+++ b/stock_move_line_multi_company_security/security/stock_security.xml
@@ -5,7 +5,7 @@
          <field name="name">stock_move_line multi-company</field>
         <field name="model_id" search="[('model','=','stock.move.line')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">[('company_id','child_of',[user.company_id.id])]</field>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id','child_of',[user.company_id.id])]</field>
      </record>
 
 </odoo>


### PR DESCRIPTION
when the move line is being created, the security rule can be hit
while checking the api.contrains methods, which can happen before the company_id
field is initialized from the stock move -> Access error is raised.

To work around this, allow working when company_id is False