### PR TITLE
[FIX] account_invoice_inter_company: Compatibility with password_security

### DIFF
--- a/account_invoice_inter_company/tests/inter_company_invoice.xml
+++ b/account_invoice_inter_company/tests/inter_company_invoice.xml
@@ -63,7 +63,7 @@
         <field name="name">User A</field>
         <field name="partner_id" ref="partner_user_a"/>
         <field name="login">usera</field>
-        <field name="password">usera</field>
+        <field name="password">usera_p4S$word</field>
         <field name="company_id" ref="company_a"/>
         <field name="company_ids" eval="[(6, 0, [ref('company_a')])]"/>
         <field name="groups_id" eval="[(6, 0, [ref('account.group_account_manager'), ref('base.group_partner_manager')])]"/>
@@ -73,7 +73,7 @@
         <field name="name">User B</field>
         <field name="partner_id" ref="partner_user_b"/>
         <field name="login">userb</field>
-        <field name="password">userb</field>
+        <field name="password">userb_p4S$word</field>
         <field name="company_id" ref="company_b"/>
         <field name="company_ids" eval="[(6, 0, [ref('company_b')])]"/>
         <field name="groups_id" eval="[(6, 0, [ref('account.group_account_manager'), ref('base.group_partner_manager')])]"/>


### PR DESCRIPTION

`password_security` asks by default for 8 chars minimum in the password. If it happens to be installed before this module, it cannot be loaded.

It's just demo data, so I just use a longer password here.

@Tecnativa