### PR TITLE
[11.0][FIX]  partner_multi_company: update partner company_ids only if the partner is not global

### DIFF
--- a/partner_multi_company/models/res_users.py
+++ b/partner_multi_company/models/res_users.py
@@ -21,5 +21,7 @@ class ResUsers(models.Model):
         res = super(ResUsers, self).write(vals)
         if 'company_id' in vals:
             for user in self.sudo():
-                user.partner_id.company_ids = [(6, 0, [vals['company_id']])]
+                if user.partner_id.company_ids:
+                    user.partner_id.company_ids = \
+                        [(6, 0, [vals['company_id']])]
         return res

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -148,3 +148,17 @@ class TestPartnerMultiCompany(common.SavepointCase):
             partner.company_ids,
             self.partner_company_both.company_ids,
         )
+
+    def test_avoid_updating_company_ids_in_global_partners(self):
+        self.user_company_1.write({
+            'company_ids': [(4, self.company_2.id)],
+        })
+        user_partner = self.user_company_1.partner_id
+        user_partner.write({
+            'company_id': False,
+            'company_ids': [(5, False)],
+        })
+        self.user_company_1.write({
+            'company_id': self.company_2.id,
+        })
+        self.assertEquals(user_partner.company_ids.ids, [])


### PR DESCRIPTION
1. You create a user. Assign the user to several companies.
2. Go the the user's partner and delete the company_ids of the partner.
3. Log with the user and change the company of the user.
4. Error: Check again the company_ids of the user's partner and you find that the field have been filled again.

We should maintain the same behavior as odoo: https://github.com/odoo/odoo/blob/11.0/odoo/addons/base/res/res_users.py#L369:
```python
# if partner is global we keep it that way
```