### PR TITLE
[12.0][account_invoice_inter_company] Fix tests when product are not shared between commpanies

### DIFF
--- a/account_invoice_inter_company/models/res_company.py
+++ b/account_invoice_inter_company/models/res_company.py
@@ -8,16 +8,17 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     company_share_product = fields.Boolean(
-        'Share product to all companies', compute='_compute_share_product')
+        'Share product to all companies', compute='_compute_share_product',
+        compute_sudo=True)
     invoice_auto_validation = fields.Boolean(
         help="When an invoice is created by a multi company rule "
              "for this company, it will automatically validate it",
         default=True)
 
     def _compute_share_product(self):
-        self.ensure_one()
         product_rule = self.env.ref('product.product_comp_rule')
-        self.company_share_product = not bool(product_rule.active)
+        for company in self:
+            company.company_share_product = not bool(product_rule.active)
 
     @api.multi
     def _get_user_domain(self):

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -50,6 +50,8 @@ class TestAccountInvoiceInterCompany(SavepointCase):
             self.assertFalse(line.product_id.company_id)
 
     def test03_confirm_invoice(self):
+        # ensure the catalog is shared
+        self.env.ref('product.product_comp_rule').write({'active': False})
         # Confirm the invoice of company A
         self.invoice_company_a.sudo(
             self.user_company_a.id).action_invoice_open()


### PR DESCRIPTION
In the test, there is a check between the product of the original invoice and the one in the inter-company invoice. But this make no sense in case the product catalog is not shared between companies. 
Consequently, the tests fails when the module is installed with product_multi_company because it active the product multi company rule.

Beside, I think the boolean `company_share_product` is not managed the correct way, IMO it should probably be just a simple boolean on company, or maybe better a global configuration (ir_parameter) if we want it to be the same for every body.
But, the fact that the multi company rule is active does not always mean the product catalog is not shared. Even with the native rule allows product to be shared (products with no company_id.
In my use case, for instance a part of the catalog is shared, but not all product and so this does not work... 
Anyway, it  was already discussed there by @bealdav @astirpe @pedrobaeza 
https://github.com/OCA/multi-company/pull/119#discussion_r269030308
It seems there was not really an agreement on this. 
I don't pretend to debate a lot more on this, I'll adapt, but I'd like to know if it would be acceptable to do it via a `ir_config_parameter`? 
We could create it in the module and it say the product catalog is shared, by default.
Put this in the accounting configuration and in the README...

If it is ok for every body, I'll make a PR about this. In the other case, I'll just manage my use case on my side and we'll see for version 13 how we will manage it...