### PR TITLE
[11.0][FIX] partner_multi_company: make display_name stored

### DIFF
--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -1,13 +1,24 @@
 # Copyright 2015 Oihane Crucelaegui
 # Copyright 2015-2019 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2019 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html.html
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
     _inherit = ["multi.company.abstract", "res.partner"]
     _name = 'res.partner'
+
+    # This is needed because after installation this field becomes
+    # unsearchable and unsortable. Which is not explicitly changed in this
+    # module and as such can be considered an undesired yield.
+    display_name = fields.Char(
+        compute="_compute_display_name",
+        store=True,
+        index=True,
+    )
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
Fixes https://github.com/OCA/multi-company/issues/84.

This is needed because after installation this field becomes unsearchable and unsortable. Which is not explicitly changed in this module and as such can be considered an undesired yield.

it is probably not a fix for the root cause but it is at at least a fix for a long-standing problem...

