### PR TITLE
12.0 FIX purch_sale_inter_cpny: split data according to companies

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 server-tools
+server-backend

--- a/purchase_sale_inter_company/__manifest__.py
+++ b/purchase_sale_inter_company/__manifest__.py
@@ -20,6 +20,7 @@
         'purchase',
         'stock',
         'account_invoice_inter_company',
+        'base_suspend_security',
     ],
     'data': [
         'views/res_config_view.xml',


### PR DESCRIPTION
when creating sale.order

cc @chafique-delli @mourad-ehm @carlosdauden 

There is the same bug in v11
https://github.com/OCA/multi-company/blob/11.0/purchase_sale_inter_company/models/purchase_order.py#L81-L82

