### PR TITLE
[FIX] account_payment_other_company: Sudo Search Read - "Search More" Option on Other Journal

### DIFF
--- a/account_payment_other_company/models/account_journal.py
+++ b/account_payment_other_company/models/account_journal.py
@@ -66,3 +66,13 @@ class AccountJournal(models.Model):
         index = {vals['id']: vals for vals in result}
         return [index[record.id] for
                 record in records if record.id in index]
+
+    @api.multi
+    def name_get(self):
+        res = []
+        journals = self.sudo()
+        for journal in journals:
+            currency = journal.currency_id or journal.company_id.currency_id
+            name = "%s (%s)" % (journal.name, currency.name)
+            res += [(journal.id, name)]
+        return res

--- a/account_payment_other_company/models/account_journal.py
+++ b/account_payment_other_company/models/account_journal.py
@@ -36,3 +36,33 @@ class AccountJournal(models.Model):
             return super()._name_search(name, args,
                                         operator, limit,
                                         name_get_uid)
+
+    @api.model
+    def search_read(self, domain=None, fields=None, offset=0,
+                    limit=None, order=None):
+        if self.env.context.get('sudo', False):
+            records = self.sudo().\
+                search(domain or [], offset=offset, limit=limit, order=order)
+        else:
+            records = self.\
+                search(domain or [], offset=offset, limit=limit, order=order)
+
+        if not records:
+            return []
+
+        if fields and fields == ['id']:
+            # shortcut read if we only want the ids
+            return [{'id': record.id} for record in records]
+        if 'active_test' in self._context:
+            context = dict(self._context)
+            del context['active_test']
+            records = records.with_context(context)
+
+        result = records.read(fields)
+        if len(result) <= 1:
+            return result
+
+        # reorder read
+        index = {vals['id']: vals for vals in result}
+        return [index[record.id] for
+                record in records if record.id in index]

--- a/account_payment_other_company/models/account_payment.py
+++ b/account_payment_other_company/models/account_payment.py
@@ -42,6 +42,7 @@ class AccountPayment(models.Model):
             'journal_id': self.other_journal_id.id,
             'state': 'draft',
             'company_id': other_journal.company_id.id,
+            'date': self.payment_date,
             'ref': self.id,
             'line_ids': [(0, 0, {
                 'account_id': other_journal.company_id.


### PR DESCRIPTION
When we click "Search More" on the Other Journal field, search_read is called and because it does not use sudo() it cannot pull the journals that are being returned by the _name_search method. Just like in _name_search, we check for 'sudo' being passed in the context, if so, then we sudo() the method itself.