### PR TITLE
[11.0][FIX] account_multicompany_easy_creation: account code digits and currency ignored

### DIFF
--- a/account_multicompany_easy_creation/README.rst
+++ b/account_multicompany_easy_creation/README.rst
@@ -42,6 +42,7 @@ Contributors
 
 * `Tecnativa <https://www.tecnativa.com>`_:
   * Carlos Dauden
+* Eric Antones - NuoBiT Solutions, S.L. <eantones@nuobit.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
@@ -135,6 +135,9 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
                 self.chart_template_id.cash_account_code_prefix,
         })
         wizard.onchange_chart_template_id()
+        if self.accounts_code_digits:
+            wizard.code_digits = self.accounts_code_digits
+        wizard.currency_id = self.currency_id
         wizard.sudo().execute()
 
     def create_bank_journals(self):


### PR DESCRIPTION
Account code digits and currency are overwrited by onchange_chart_template_id method