### PR TITLE
[IMP] account_move_multi_company: Copy Line Label to Other Journal Entries

### DIFF
--- a/account_move_multi_company/models/account_move.py
+++ b/account_move_multi_company/models/account_move.py
@@ -16,6 +16,7 @@ class AccountMove(models.Model):
             debit = line.credit
             credit = line.debit
         return {
+            'name': line.name,
             'account_id':
                 account and account.id or
                 line.transfer_to_company_id.due_to_account_id.id,
@@ -38,11 +39,13 @@ class AccountMove(models.Model):
                     company_id = line.transfer_to_company_id.id
                     # Add the lines for the current company journal entry
                     transfer_lines.append((0, 0, {
+                        'name': line.name,
                         'account_id': line.account_id.id,
                         'partner_id': line.partner_id.id,
                         'debit': line.credit,
                         'credit': line.debit}))
                     transfer_lines.append((0, 0, {
+                        'name': line.name,
                         'account_id':
                             self.env.user.company_id.due_from_account_id.id,
                         'partner_id':


### PR DESCRIPTION
When making a Transfers, copy the Label from the original Journal Entry over to the others for traceability 