### PR TITLE
[IMP] account_move_multi_company: Compare ID's Properly

### DIFF
--- a/account_move_multi_company/models/account_move.py
+++ b/account_move_multi_company/models/account_move.py
@@ -50,7 +50,7 @@ class AccountMove(models.Model):
                         'debit': line.debit,
                         'credit': line.credit}))
 
-                    if line.transfer_to_company_id not in\
+                    if line.transfer_to_company_id.id not in\
                             dedicated_companies_vals:
                         account = \
                             self.env['account.account'].sudo().with_context(


### PR DESCRIPTION
This if statement will always return True. This is because we are storing an integer value of the company_id in line 69. The if statement will compare "res_company(1)" == "1" because of this it never finds the company_id in the dedicated_companies_vals and will always overwrite the previous value for that company instead of appending it. So if I have 2 Transfer To's to the same company, only one will be shown because they will overwrite each other.

The test cases only check to see if a JE is created in the Transfer To companies and they are, they just do not have the proper line items. This is why this error never showed up in travis.