### PR TITLE
[IMP] account_payment_other_company: Add Multi Invoice Functionality + Check Lock Dates

### DIFF
--- a/account_payment_other_company/models/account_move.py
+++ b/account_payment_other_company/models/account_move.py
@@ -9,4 +9,4 @@ class AccountMove(models.Model):
     def _post_validate(self):
         # Override to prevent ValidationError
         # Method in odoo/addons/account/models/account_move line 357
-        return True
+        return self._check_lock_date()

--- a/account_payment_other_company/models/account_payment.py
+++ b/account_payment_other_company/models/account_payment.py
@@ -30,6 +30,7 @@ class AccountPayment(models.Model):
     def create_move_other_company(self):
         res = {}
         for rec in self:
+            rec.onchange_show_other_journal()
             if rec.other_journal_id:
                 other_company = rec.sudo().other_journal_id.company_id
                 # Update the existing move

--- a/account_payment_other_company/wizard/__init__.py
+++ b/account_payment_other_company/wizard/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from . import models
-from . import wizard
+from . import (
+    account_register_payments,
+)

--- a/account_payment_other_company/wizard/account_register_payments.py
+++ b/account_payment_other_company/wizard/account_register_payments.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2019 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class account_register_payments(models.TransientModel):
+    _inherit = "account.register.payments"
+    _description = "Register Payments"
+
+    other_journal_id = fields.Many2one(
+        'account.journal', string='Paid By',
+        domain=[('type', 'in', ('bank', 'cash'))])
+    show_other_journal = fields.Boolean(default=False, invisible=True)
+    company_id = fields.\
+        Many2one('res.company', related='journal_id.company_id',
+                 string='Company', readonly=True)
+
+    @api.multi
+    @api.onchange('journal_id', 'payment_type')
+    def onchange_show_other_journal(self):
+        for rec in self:
+            res = (rec.journal_id.id == rec.company_id.
+                   due_fromto_payment_journal_id.id and
+                   rec.payment_type in ('outbound', 'inbound') and
+                   rec.partner_type == 'supplier')
+            # If False, reset the other journal
+            if not res:
+                rec.other_journal_id = False
+            rec.show_other_journal = res
+
+    @api.multi
+    def create_payments(self):
+        res = super().create_payments()
+        if self.show_other_journal:
+            for pay_id in res['domain'][0][2]:
+                payment_id = self.env['account.payment'].browse(pay_id)
+                payment_id.\
+                    write({'other_journal_id': self.other_journal_id.id})
+                payment_id.create_move_other_company()
+        return res
+
+    @api.model
+    def default_get(self, fields):
+        rec = super().default_get(fields)
+        active_ids = self._context.get('active_ids')
+        active_model = self._context.get('active_model')
+        # Check for selected invoices ids
+        if not active_ids or active_model != 'account.invoice':
+            return rec
+        invoices = self.env['account.invoice'].browse(active_ids)
+        # Check all invoices are for suppliers
+        if all(invoice.partner_id.supplier for invoice in invoices):
+            rec.update({'partner_type': 'supplier'})
+        return rec

--- a/account_payment_other_company/wizard/account_register_payments.xml
+++ b/account_payment_other_company/wizard/account_register_payments.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record id="view_account_payment_from_invoices_multi_company" model="ir.ui.view">
+            <field name="name">account.register.payments.wizard</field>
+            <field name="model">account.register.payments</field>
+            <field name="inherit_id" ref="account.view_account_payment_from_invoices"/>
+            <field name="arch" type="xml">
+                <field name="journal_id" position="after">
+                    <field name="company_id" attrs="{'invisible': True}"/>
+                    <field name="other_journal_id"
+                        domain="[('type', 'in', ['bank', 'cash']), ('company_id','!=', company_id)]"
+                        attrs="{'invisible': [('show_other_journal', '=', False)], 'required': [('show_other_journal', '=', True)]}"
+                        context="{'sudo': True}"/>
+                    <field name="show_other_journal" attrs="{'invisible': True}"/>
+                </field>
+            </field>
+        </record>
+</odoo>


### PR DESCRIPTION
Currently you can only pay 1 invoice at a time through the Account Payment Other Company module. This PR allows the same functionality to be applied on multiple invoices through the list view of Vendor Bills.

UPDATE: We encountered an error where JE's were being validated despite having an invoice date before the Lock Date set by the user. This is because we overwrite the _post_validate() in the account_move.py file. Instead of "return True" we "self._check_lock_date()" just like core odoo does here: https://github.com/ursais/odoo/blob/ebf7fcd679143853b8e387c2119b660364785119/addons/account/models/account_move.py#L363