### PR TITLE
[13.0][IMP] account_invoice_inter_company: Remove onchange_helper dependency

### DIFF
--- a/account_invoice_inter_company/README.rst
+++ b/account_invoice_inter_company/README.rst
@@ -78,9 +78,13 @@ Contributors
 * Chafique Delli <chafique.delli@akretion.com>
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Andrea Stirpe <a.stirpe@onestein.nl>
-* Jairo Llopis <jairo.llopis@tecnativa.com>
 * David Beal <david.beal@akretion.com>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
+* `Tecnativa <https://www.tecnativa.com>`:
+
+  * Jairo Llopis
+  * David Vidal
+  * Pedro M. Baeza
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_inter_company/__manifest__.py
+++ b/account_invoice_inter_company/__manifest__.py
@@ -10,7 +10,7 @@
     "website": "https://github.com/OCA/multi-company",
     "author": "Odoo SA, Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["account", "onchange_helper"],
-    "data": ["views/res_config_settings_view.xml"],
+    "depends": ["account"],
+    "data": ["views/account_move_views.xml", "views/res_config_settings_view.xml"],
     "installable": True,
 }

--- a/account_invoice_inter_company/__manifest__.py
+++ b/account_invoice_inter_company/__manifest__.py
@@ -1,5 +1,7 @@
 # Copyright 2013-2014 Odoo SA
 # Copyright 2015-2017 Chafique Delli <chafique.delli@akretion.com>
+# Copyright 2020 Tecnativa - David Vidal
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -259,4 +259,9 @@ class AccountMoveLine(models.Model):
             line_form.sequence = self.sequence
         vals = dest_form._values_to_save(all_fields=True)["invoice_line_ids"][0][2]
         vals.update({"move_id": dest_move.id, "auto_invoice_line_id": self.id})
+        if self.analytic_account_id and not self.analytic_account_id.company_id:
+            vals["analytic_account_id"] = self.analytic_account_id.id
+            analytic_tags = self.analytic_tag_ids.filtered(lambda x: not x.company_id)
+            if analytic_tags:
+                vals["analytic_tag_ids"] = [(4, x) for x in analytic_tags.ids]
         return vals

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -2,6 +2,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tests.common import Form
 from odoo.tools import float_compare
 
 
@@ -168,35 +169,28 @@ class AccountMove(models.Model):
                 _('Please define %s journal for this company: "%s" (id:%d).')
                 % (dest_journal_type, dest_company.name, dest_company.id)
             )
-        # find account, payment term, fiscal position, bank.
-        dest_partner_data = {
-            "type": dest_inv_type,
-            "partner_id": self.company_id.partner_id.id,
-            "company_id": dest_company.id,
-        }
-        dest_partner_data = self.env["account.move"].play_onchanges(
-            dest_partner_data, ["partner_id"]
+        # Use test.Form() class to trigger propper onchanges on the invoice
+        dest_invoice_data = Form(
+            self.env["account.move"].with_context(
+                default_type=dest_inv_type, force_company=dest_company.id
+            )
         )
-        return {
-            "invoice_origin": _("%s - Invoice: %s") % (self.company_id.name, self.name),
-            "type": dest_inv_type,
-            "invoice_date": self.invoice_date,
-            "ref": self.name,
-            "partner_id": self.company_id.partner_id.id,
-            "journal_id": dest_journal.id,
-            "currency_id": self.currency_id.id,
-            "fiscal_position_id": dest_partner_data.get("fiscal_position_id", False),
-            "invoice_payment_term_id": dest_partner_data.get(
-                "invoice_payment_term_id", False
-            ),
-            "company_id": dest_company.id,
-            "invoice_partner_bank_id": dest_partner_data.get(
-                "invoice_partner_bank_id", False
-            ),
-            "auto_generated": True,
-            "auto_invoice_id": self.id,
-            "narration": self.narration,
-        }
+        dest_invoice_data.journal_id = dest_journal
+        dest_invoice_data.partner_id = self.company_id.partner_id
+        dest_invoice_data.ref = self.name
+        dest_invoice_data.invoice_date = self.invoice_date
+        dest_invoice_data.narration = self.narration
+        dest_invoice_data.currency_id = self.currency_id
+        vals = dest_invoice_data._values_to_save(all_fields=True)
+        vals.update(
+            {
+                "invoice_origin": _("%s - Invoice: %s")
+                % (self.company_id.name, self.name),
+                "auto_invoice_id": self.id,
+                "auto_generated": True,
+            }
+        )
+        return vals
 
     def button_cancel(self):
         for invoice in self:
@@ -237,68 +231,32 @@ class AccountMoveLine(models.Model):
             :rtype dest_company : res.company record
         """
         self.ensure_one()
-        src_company_partner = self.move_id.company_id.partner_id
-        # get account move line data from product onchange
-        dest_line_data = {
-            "name": "",
-            "move_id": dest_move.id,
-            "product_id": self.product_id.id,
-            "product_uom_id": self.product_id.uom_id.id,
-            "quantity": self.quantity,
-            "partner_id": src_company_partner.id,
-            "company_id": dest_company.id,
-        }
-        dest_line_data = self.env["account.move.line"].play_onchanges(
-            dest_line_data, ["product_id"]
+        # Use test.Form() class to trigger propper onchanges on the line
+        product = (
+            dest_company.company_share_product
+            and self.product_id
+            or self.env["product.product"]
         )
-        account_id = dest_line_data.get("account_id", False)
-        if account_id:
-            account = self.env["account.account"].browse(account_id)
-        else:
-            account = self.env["account.account"].search(
-                [
-                    (
-                        "user_type_id",
-                        "=",
-                        self.env.ref("account.data_account_type_revenue").id,
-                    ),
-                    ("company_id", "=", dest_company.id),
-                ],
-                limit=1,
-            )
-            if not account:
-                raise UserError(
-                    _('Please define %s account for this company: "%s" (id:%d).')
-                    % (
-                        self.env.ref("account.data_account_type_revenue").name,
-                        dest_company.name,
-                        dest_company.id,
-                    )
-                )
-        tax_ids = dest_line_data.get("tax_ids", False)
-        product_id = False
-        if dest_company.company_share_product:
-            product_id = self.product_id.id
-        vals = {
-            "name": self.name,
-            "move_id": dest_line_data.get("move_id", False),
+        dest_form = Form(
+            dest_move.with_context(force_company=dest_company.id),
+            "account_invoice_inter_company.view_move_form",
+        )
+        with dest_form.invoice_line_ids.new() as line_form:
+            # HACK: Related fields manually set due to Form() limitations
+            line_form.company_id = dest_move.company_id
+            # Regular fields
+            line_form.display_type = self.display_type
+            line_form.product_id = product
+            line_form.name = self.name
+            if line_form.product_uom_id != self.product_uom_id:
+                line_form.product_uom_id = self.product_uom_id
+            line_form.quantity = self.quantity
             # TODO: it's wrong to just copy the price_unit
             # You have to check if the tax is price_include True or False
             # in source and target companies
-            "price_unit": self.price_unit,
-            "quantity": self.quantity,
-            "discount": self.discount,
-            "product_id": product_id,
-            "sequence": self.sequence,
-            "tax_ids": tax_ids or [],
-            # Analytic accounts are per company
-            # The problem is that we can't really "guess" the
-            # analytic account to set. It probably needs to be
-            # set via an inherit of this method in a custom module
-            "analytic_account_id": dest_line_data.get("analytic_account_id", False),
-            "account_id": account.id or False,
-            "auto_invoice_line_id": self.id,
-            "partner_id": src_company_partner.id,
-            "company_id": dest_company.id,
-        }
+            line_form.price_unit = self.price_unit
+            line_form.discount = self.discount
+            line_form.sequence = self.sequence
+        vals = dest_form._values_to_save(all_fields=True)["invoice_line_ids"][0][2]
+        vals.update({"move_id": dest_move.id, "auto_invoice_line_id": self.id})
         return vals

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -92,6 +92,7 @@ class AccountMove(models.Model):
             dest_invoice_data["move_name"] = force_number
         dest_invoice = self.create(dest_invoice_data)
         # create invoice lines
+        dest_move_line_data = []
         for src_line in self.invoice_line_ids:
             if dest_company.company_share_product and not src_line.product_id:
                 raise UserError(
@@ -102,9 +103,10 @@ class AccountMove(models.Model):
                     )
                     % src_line.name
                 )
-            self.env["account.move.line"].create(
+            dest_move_line_data.append(
                 src_line._prepare_account_move_line(dest_invoice, dest_company)
             )
+        self.env["account.move.line"].create(dest_move_line_data)
         dest_invoice._move_autocomplete_invoice_lines_values()
         # Validation of account invoice
         precision = self.env["decimal.precision"].precision_get("Account")

--- a/account_invoice_inter_company/readme/CONTRIBUTORS.rst
+++ b/account_invoice_inter_company/readme/CONTRIBUTORS.rst
@@ -2,6 +2,10 @@
 * Chafique Delli <chafique.delli@akretion.com>
 * Alexis de Lattre <alexis.delattre@akretion.com>
 * Andrea Stirpe <a.stirpe@onestein.nl>
-* Jairo Llopis <jairo.llopis@tecnativa.com>
 * David Beal <david.beal@akretion.com>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
+* `Tecnativa <https://www.tecnativa.com>`:
+
+  * Jairo Llopis
+  * David Vidal
+  * Pedro M. Baeza

--- a/account_invoice_inter_company/static/description/index.html
+++ b/account_invoice_inter_company/static/description/index.html
@@ -426,9 +426,14 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Alexis de Lattre &lt;<a class="reference external" href="mailto:alexis.delattre&#64;akretion.com">alexis.delattre&#64;akretion.com</a>&gt;</li>
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
-<li>Jairo Llopis &lt;<a class="reference external" href="mailto:jairo.llopis&#64;tecnativa.com">jairo.llopis&#64;tecnativa.com</a>&gt;</li>
 <li>David Beal &lt;<a class="reference external" href="mailto:david.beal&#64;akretion.com">david.beal&#64;akretion.com</a>&gt;</li>
 <li>Adria Gil Sorribes &lt;<a class="reference external" href="mailto:adria.gil&#64;forgeflow.com">adria.gil&#64;forgeflow.com</a>&gt;</li>
+<li><cite>Tecnativa &lt;https://www.tecnativa.com&gt;</cite>:<ul>
+<li>Jairo Llopis</li>
+<li>David Vidal</li>
+<li>Pedro M. Baeza</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_invoice_inter_company/tests/inter_company_invoice.xml
+++ b/account_invoice_inter_company/tests/inter_company_invoice.xml
@@ -403,6 +403,7 @@
             (0, 0, {
                 'product_id': ref('product_consultant_multi_company'),
                 'price_unit': 450.0, 'quantity': 1,
+                'product_uom_id': ref('uom.product_uom_hour'),
                 'name': 'Service Multi Company',
                 'company_id': ref('company_a'),
             }),

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -1,4 +1,6 @@
 # Copyright 2015-2017 Chafique Delli <chafique.delli@akretion.com>
+# Copyright 2020 Tecnativa - David Vidal
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _
@@ -12,11 +14,11 @@ class TestAccountInvoiceInterCompanyBase(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        module = "account_invoice_inter_company"
+        cls.module = __name__.split("addons.")[1].split(".")[0]
         convert_file(
             cls.cr,
-            module,
-            get_resource_path(module, "tests", "inter_company_invoice.xml"),
+            cls.module,
+            get_resource_path(cls.module, "tests", "inter_company_invoice.xml"),
             None,
             "init",
             False,
@@ -25,11 +27,9 @@ class TestAccountInvoiceInterCompanyBase(SavepointCase):
         )
         cls.account_obj = cls.env["account.account"]
         cls.account_move_obj = cls.env["account.move"]
-        cls.invoice_company_a = cls.env.ref(
-            "account_invoice_inter_company.customer_invoice_company_a"
-        )
-        cls.user_company_a = cls.env.ref("account_invoice_inter_company.user_company_a")
-        cls.user_company_b = cls.env.ref("account_invoice_inter_company.user_company_b")
+        cls.invoice_company_a = cls.env.ref(cls.module + ".customer_invoice_company_a")
+        cls.user_company_a = cls.env.ref(cls.module + ".user_company_a")
+        cls.user_company_b = cls.env.ref(cls.module + ".user_company_b")
         cls.company_a = cls.env.ref("account_invoice_inter_company.company_a")
         cls.company_b = cls.env.ref("account_invoice_inter_company.company_b")
         cls.company_a.invoice_auto_validation = True
@@ -40,6 +40,15 @@ class TestAccountInvoiceInterCompanyBase(SavepointCase):
         ).property_account_expense_id = cls.env.ref(
             "account_invoice_inter_company.a_expense_company_b"
         ).id
+        cls.invoice_line_b = cls.env["account.move.line"].create(
+            {
+                "move_id": cls.invoice_company_a.id,
+                "product_id": cls.product_a.id,
+                "name": "Test second line",
+                "account_id": cls.env.ref(cls.module + ".a_sale_company_a").id,
+                "price_unit": 20,
+            }
+        )
         cls.chart = cls.env["account.chart.template"].search([], limit=1)
         if not cls.chart:
             raise ValidationError(

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -33,7 +33,8 @@ class TestAccountInvoiceInterCompanyBase(SavepointCase):
         cls.company_a = cls.env.ref("account_invoice_inter_company.company_a")
         cls.company_b = cls.env.ref("account_invoice_inter_company.company_b")
         cls.company_a.invoice_auto_validation = True
-        cls.product_a = cls.invoice_company_a.invoice_line_ids.product_id
+        cls.invoice_line_a = cls.invoice_company_a.invoice_line_ids[0]
+        cls.product_a = cls.invoice_line_a.product_id
         cls.product_a.with_context(
             force_company=cls.company_b.id
         ).property_account_expense_id = cls.env.ref(
@@ -72,6 +73,19 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
         self.product_a.with_context(
             force_company=self.user_company_b.id
         ).supplier_taxes_id = False
+        # Put some analytic data for checking its propagation
+        analytic_account = self.env["account.analytic.account"].create(
+            {"name": "Test analytic account", "company_id": False}
+        )
+        analytic_tag = self.env["account.analytic.tag"].create(
+            {"name": "Test analytic tag", "company_id": False}
+        )
+        self.invoice_line_a.analytic_account_id = analytic_account.id
+        self.invoice_line_a.analytic_tag_ids = [(4, analytic_tag.id)]
+        # Give user A permission to analytic
+        self.user_company_a.groups_id = [
+            (4, self.env.ref("analytic.group_analytic_accounting").id)
+        ]
         # Confirm the invoice of company A
         self.invoice_company_a.with_user(self.user_company_a.id).action_post()
         # Check destination invoice created in company B
@@ -91,9 +105,16 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
             len(invoices[0].invoice_line_ids),
             len(self.invoice_company_a.invoice_line_ids),
         )
+        invoice_line = invoices[0].invoice_line_ids[0]
         self.assertEquals(
-            invoices[0].invoice_line_ids[0].product_id,
+            invoice_line.product_id,
             self.invoice_company_a.invoice_line_ids[0].product_id,
+        )
+        self.assertEquals(
+            invoice_line.analytic_account_id, self.invoice_line_a.analytic_account_id
+        )
+        self.assertEquals(
+            invoice_line.analytic_tag_ids, self.invoice_line_a.analytic_tag_ids
         )
         # Cancel the invoice of company A
         invoice_origin = ("%s - Canceled Invoice: %s") % (

--- a/account_invoice_inter_company/views/account_move_views.xml
+++ b/account_invoice_inter_company/views/account_move_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field
+            name="name"
+        >account.move.form - HACK: Extra fields for odoo.tests.Form() to work</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']/tree" position="inside">
+                <field name="company_id" invisible="0" readonly="0" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Removes `onchange_helper` dependency and uses fancy `Form` class for the equivalent one (and even more complete and bullet-proof).

Forward-port to v13 of #218

cc @Tecnativa TT21089