### PR TITLE
[FIX] account_move_multi_company: Check ID in IF statement

### DIFF
--- a/account_move_multi_company/models/account_move.py
+++ b/account_move_multi_company/models/account_move.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
                         'debit': line.debit,
                         'credit': line.credit}))
 
-                    if line.transfer_to_company_id not in\
+                    if line.transfer_to_company_id.id not in\
                             dedicated_companies_vals:
                         account = \
                             self.env['account.account'].sudo().with_context(


### PR DESCRIPTION
This if statement is incorrect. "dedicated_companies_vals" is a dictionary where "company_id" is an integer. "line.transfer_to_company_id" returns res.company(X) so the if statement always evaluates to False. Adding ".id" fixes this issue and the if statement works as intended