### PR TITLE
[13.0][FIX] base_multi_company: incompatibility error

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -26,9 +26,10 @@ class MultiCompanyAbstract(models.AbstractModel):
 
     @api.depends("company_ids")
     def _compute_company_id(self):
-        current_companies = self.env.companies
         for record in self:
-            if all(elem in record.company_ids.ids for elem in current_companies.ids):
+            # Give the priority of the current company of the user to avoid
+            # multi company incompatibility errors.
+            if self.env.company in record.company_ids:
                 record.company_id = self.env.company.id
             else:
                 record.company_id = record.company_ids[:1].id


### PR DESCRIPTION
if you have several companies active and any of them with
lower id than the current company, you can get multi-company
inconsistency errors.

E.g: when reserving stock pickings, product company is computed
and might be different than the move's company.

![image](https://user-images.githubusercontent.com/23449160/86607557-b24d2580-bfa9-11ea-9983-93e4143ae25e.png)


@ForgeFlow