### PR TITLE
[FIX] acccount_payment_other_company: Search Due From not Due To

### DIFF
--- a/account_payment_other_company/__manifest__.py
+++ b/account_payment_other_company/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     'data': [
         'views/account_payment.xml',
+        'views/account_register_payments.xml'
     ],
     'development_status': 'Beta',
     'maintainers': [

--- a/account_payment_other_company/__manifest__.py
+++ b/account_payment_other_company/__manifest__.py
@@ -15,7 +15,7 @@
     ],
     'data': [
         'views/account_payment.xml',
-        'views/account_register_payments.xml'
+        'wizard/account_register_payments.xml'
     ],
     'development_status': 'Beta',
     'maintainers': [

--- a/account_payment_other_company/models/account_payment.py
+++ b/account_payment_other_company/models/account_payment.py
@@ -47,7 +47,7 @@ class AccountPayment(models.Model):
                 else:
                     aml = self.env['account.move.line'].search([
                         ('account_id', '=',
-                         rec.company_id.due_to_account_id.id),
+                         rec.company_id.due_from_account_id.id),
                         ('payment_id', '=', rec.id)])
                     aml.partner_id = other_company.partner_id.id
                     account_move = self.env['account.move']

--- a/account_payment_other_company/models/account_payment.py
+++ b/account_payment_other_company/models/account_payment.py
@@ -49,7 +49,7 @@ class AccountPayment(models.Model):
                         ('account_id', '=',
                          rec.company_id.due_from_account_id.id),
                         ('payment_id', '=', rec.id)])
-                    aml.partner_id = other_company.partner_id.id
+                    aml.write({'partner_id' : other_company.partner_id.id})
                     account_move = self.env['account.move']
                     vals = rec._prepare_other_payment_values()
                     rec.other_move_id = account_move.sudo().with_context(

--- a/account_payment_other_company/tests/test_account_payment.py
+++ b/account_payment_other_company/tests/test_account_payment.py
@@ -49,18 +49,17 @@ class TestAccountPayment(SavepointCase):
                 'account_payment_other_company.a_expense_company_b'
             )
 
-        cls.company_a.due_from_account_id = cls.env.ref(
-            'account_payment_other_company.a_pay_company_a'
-        )
-        cls.company_a.due_to_account_id = cls.env.ref(
-            'account_payment_other_company.a_recv_company_a'
-        )
-        cls.company_b.due_from_account_id = cls.env.ref(
-            'account_payment_other_company.a_recv_company_b'
-        )
-        cls.company_b.due_to_account_id = cls.env.ref(
-            'account_payment_other_company.a_pay_company_b'
-        )
+        cls.company_a.due_from_account_id = cls.company_a.\
+            due_fromto_payment_journal_id.default_debit_account_id
+
+        cls.company_a.due_to_account_id = cls.company_a.\
+            due_fromto_payment_journal_id.default_credit_account_id
+
+        cls.company_b.due_from_account_id = cls.company_b.\
+            due_fromto_payment_journal_id.default_debit_account_id
+
+        cls.company_b.due_to_account_id = cls.company_b.\
+            due_fromto_payment_journal_id.default_credit_account_id
 
         cls.company_a_journal = cls.env.\
             ref('account_payment_other_company.bank_journal_company_a')


### PR DESCRIPTION
Because we are searching for Account Move Lines in the current company, we expect to see the Due From account not the Due To