### PR TITLE
[13.0][FIX] base_multi_company: consider force_company context key.

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -29,8 +29,9 @@ class MultiCompanyAbstract(models.AbstractModel):
         for record in self:
             # Give the priority of the current company of the user to avoid
             # multi company incompatibility errors.
-            if self.env.company in record.company_ids:
-                record.company_id = self.env.company.id
+            company_id = self.env.context.get("force_company") or self.env.company.id
+            if company_id in record.company_ids.ids:
+                record.company_id = company_id
             else:
                 record.company_id = record.company_ids[:1].id
 


### PR DESCRIPTION
Yet another fix more for OCA multi company :laughing: - Keep in mind that multi-company functionality has changed a lot in v13 and it is hard to find all corner cases.

This is needed for transactions in which the company is forced, e.g
intercompany PO/SO synchronization.

@ForgeFlow