### PR TITLE
[10.0][FIX] Multiples fixes to make 10.0 branch green

### DIFF
--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -222,6 +222,7 @@ class AccountInvoice(models.Model):
             :rtype src_company_partner_id : res.partner record
         """
         # get invoice line data from product onchange
+
         dest_line_data = {
             'product_id': src_line.product_id.id,
             'uom_id': src_line.product_id.uom_id.id,
@@ -231,8 +232,9 @@ class AccountInvoice(models.Model):
             'company_id': dest_company.id,
             'invoice_id': dest_invoice.id,
         }
-        dest_line_data = self.env['account.invoice.line'].play_onchanges(
-            dest_line_data, ['product_id'])
+        new_values = self.env['account.invoice.line'].play_onchanges(
+            dest_line_data, ['product_id', 'uom_id'])
+        dest_line_data.update(new_values)
         account_id = dest_line_data.get('account_id', False)
         if account_id:
             account = self.env['account.account'].browse(account_id)

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -157,7 +157,7 @@ class TestMultiCompanyAbstract(common.SavepointCase):
             'company_id': company1.id,
             'company_ids': [(6, False, companies.ids)],
         })
-        tester = tester_obj.create({
+        tester = tester_obj.sudo(user).create({
             'name': 'My tester',
             'company_ids': [(6, False, companies.ids)],
         })


### PR DESCRIPTION
* [x] Since Odoo commit https://github.com/odoo/odoo/commit/e93fa785629500e997330731d84853eb2edac299, it is
not allowed anymore to access a wizard that has been created
with another user.
* [x] Wrong use of onchange_helper in account_invoice_inter_company
* [x] Since Odoo commit https://github.com/odoo/odoo/commit/cd3790c4ea19efd6800284a6471158b9c75b29ca the module purchase_sale_inter_company does not work anymore. This error should not happen as the test seems to be wrong (using partner/product_multi_company in module tests with no code depending on it)