### PR TITLE
12 IMP acc_inv_inter_cpny: detect intercompany with commercial_partner_id

### DIFF
--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -26,7 +26,7 @@ class AccountInvoice(models.Model):
     def _find_company_from_invoice_partner(self):
         self.ensure_one()
         company = self.env['res.company'].sudo().search([
-            ('partner_id', '=', self.partner_id.id)
+            ('partner_id', '=', self.commercial_partner_id.id)
         ], limit=1)
         return company or False
 

--- a/account_invoice_inter_company/readme/CONTRIBUTORS.rst
+++ b/account_invoice_inter_company/readme/CONTRIBUTORS.rst
@@ -1,8 +1,11 @@
 * Odoo S.A. (original module `inter_company_rules`)
-* Chafique Delli <chafique.delli@akretion.com>
-* Alexis de Lattre <alexis.delattre@akretion.com>
 * Andrea Stirpe <a.stirpe@onestein.nl>
-* David Beal <david.beal@akretion.com>
+* `Akretion <https://www.akretion.com>`:
+
+ * Chafique Delli <chafique.delli@akretion.com>
+ * Alexis de Lattre <alexis.delattre@akretion.com>
+ * David Beal <david.beal@akretion.com>
+
 * `Tecnativa <https://www.tecnativa.com>`:
 
   * Jairo Llopis

--- a/account_invoice_inter_company/tests/inter_company_invoice.xml
+++ b/account_invoice_inter_company/tests/inter_company_invoice.xml
@@ -17,6 +17,11 @@
         <field name="supplier" eval="False"/>
         <field name="company_id" eval="False"/>
     </record>
+    <record id="child_partner_company_b" model="res.partner">
+        <field name="name">Child, Company A</field>
+        <field name="company_id" eval="False"/>
+        <field name="parent_id" ref="partner_company_b"/>
+    </record>
 
     <!--
         Create company A and B


### PR DESCRIPTION
## before
If you use any contact of the multicompany partner in your invoice, workflow is not triggered, whereas you may create an additionnal contact to specify some particular data like (specific email or any)

## after
All contact of the customer company used in invoice trigger intercompany workflow. It's more intuitive. 