### PR TITLE
12.0 IMP Account_invoice_inter_company about shared catalog result

### DIFF
--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -51,7 +51,7 @@ class AccountInvoice(models.Model):
     @api.multi
     def _check_intercompany_product(self, dest_company):
         self.ensure_one()
-        if not dest_company.company_share_product:
+        if dest_company.company_share_product:
             return
         domain = dest_company._get_user_domain()
         dest_user = self.env['res.users'].search(domain, limit=1)
@@ -94,8 +94,7 @@ class AccountInvoice(models.Model):
         # create invoice lines
         dest_inv_line_data = []
         for src_line in self.invoice_line_ids:
-            if dest_company.company_share_product and \
-                    not src_line.product_id:
+            if not src_line.product_id:
                 raise UserError(_(
                     "The invoice line '%s' doesn't have a product. "
                     "All invoice lines should have a product for "
@@ -229,9 +228,7 @@ class AccountInvoiceLine(models.Model):
         """
         self.ensure_one()
         # Use test.Form() class to trigger propper onchanges on the line
-        product = (
-            dest_company.company_share_product and self.product_id or
-            self.env['product.product'])
+        product = self.product_id or False
         dest_invoice_form = Form(
             dest_invoice.with_context(force_company=dest_company.id),
             'account_invoice_inter_company.invoice_supplier_form',

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -5,7 +5,7 @@
 
 from odoo import _
 from odoo.tests.common import SavepointCase
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError, UserError
 from odoo.modules.module import get_resource_path
 from odoo.tools import convert_file
 
@@ -23,6 +23,7 @@ class TestAccountInvoiceInterCompanyBase(SavepointCase):
         cls.module = __name__.split('addons.')[1].split('.')[0]
         cls.account_obj = cls.env['account.account']
         cls.invoice_obj = cls.env['account.invoice']
+        cls.company_a = cls.env.ref(cls.module + ".company_a")
         cls.invoice_company_a = cls.env.ref(
             cls.module + '.customer_invoice_company_a')
         cls.user_company_a = cls.env.ref(cls.module + '.user_company_a')
@@ -137,10 +138,6 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
     def test_confirm_invoice_with_child_partner(self):
         # ensure the catalog is shared
         self.env.ref('product.product_comp_rule').write({'active': False})
-        # Make sure there are no taxes in target company for the used product
-        self.product_a.with_context(
-            force_company=self.user_company_b.id
-        ).supplier_taxes_id = False
         # When a contact of the company is defined as partner,
         # it also must trigger the intercompany workflow
         self.invoice_company_a.write({"partner_id": self.user_child_company_b.id})
@@ -153,3 +150,50 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
             ('auto_invoice_id', '=', self.invoice_company_a.id)
         ])
         self.assertEqual(len(invoices), 1)
+
+    def test_confirm_invoice_with_product_and_shared_catalog(self):
+        """ With no security rule, child company have access to any product.
+            Then child invoice can share the same product
+        """
+        # ensure the catalog is shared even if product is in other company
+        self.env.ref('product.product_comp_rule').write({'active': False})
+        # Product is set to a specific company
+        self.product_a.write({"company_id": self.company_a.id})
+        invoices = self._confirm_invoice_with_product()
+        self.assertNotEqual(
+            invoices.invoice_line_ids[0].product_id, self.env["product.product"])
+
+    def test_confirm_invoice_with_native_product_rule_and_shared_product(self):
+        """ With native security rule, products with access in both companies
+            must be present in parent and child invoices.
+        """
+        # ensure the catalog is shared even if product is in other company
+        self.env.ref('product.product_comp_rule').write({'active': True})
+        # Product is set to a specific company
+        self.product_a.write({"company_id": False})
+        invoices = self._confirm_invoice_with_product()
+        self.assertEqual(
+            invoices.invoice_line_ids[0].product_id, self.product_a)
+
+    def test_confirm_invoice_with_native_product_rule_and_unshared_product(self):
+        """ With native security rule, products with no access in both companies
+            must prevent child invoice creation.
+        """
+        # ensure the catalog is shared even if product is in other company
+        self.env.ref('product.product_comp_rule').write({'active': True})
+        # Product is set to a specific company
+        self.product_a.write({"company_id": self.company_a.id})
+        with self.assertRaises(UserError):
+            self._confirm_invoice_with_product()
+
+    def _confirm_invoice_with_product(self):
+        # Confirm the invoice of company A
+        self.invoice_company_a.with_context(
+            test_account_invoice_inter_company=True,
+        ).sudo(self.user_company_a.id).action_invoice_open()
+        # Check destination invoice created in company B
+        invoices = self.invoice_obj.sudo(self.user_company_b.id).search([
+            ('auto_invoice_id', '=', self.invoice_company_a.id)
+        ])
+        self.assertEqual(len(invoices), 1)
+        return invoices


### PR DESCRIPTION
- [x] Restore coherent behavior
- [x] units tests

if company_share_product then no need any check (open bar security) https://github.com/OCA/multi-company/pull/243/files#diff-f3dbb4d976b961b82830144ced118a64R54
else it's product security rule which is applied then we check all products in _check_intercompany_product() before to validate.

Fix https://github.com/OCA/multi-company/issues/242 cc @florian-dacosta @pedrobaeza @chienandalu @mourad-ehm @astirpe