### PR TITLE
[FIX] do not raise an error if user doesn't have access to any company

### DIFF
--- a/res_company_code/models/ir_http.py
+++ b/res_company_code/models/ir_http.py
@@ -16,11 +16,12 @@ class Http(models.AbstractModel):
         display_switch_company_menu = user.has_group(
             'base.group_multi_company') and len(user.company_ids) > 1
 
-        # Replace company name by company complete name in the session
-        # The values are used in the switch_company_menu widget (web module)
-        result["user_companies"]["current_company"] = (
-            user.company_id.id, user.company_id.complete_name)
         if display_switch_company_menu:
+            # Replace company name by company complete name in the session
+            # The values are used in the switch_company_menu widget
+            # (web module)
+            result["user_companies"]["current_company"] = (
+                user.company_id.id, user.company_id.complete_name)
             result["user_companies"]["allowed_companies"] = [
                 (comp.id, comp.complete_name) for comp in user.company_ids
             ]


### PR DESCRIPTION
Trivial patch. an error is raised in some cases if user doesn't have access to many companies. This patch is fixing that.