### PR TITLE
[FIX] Restore prettier XML configuration

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -5,4 +5,4 @@ printWidth: 88
 proseWrap: always
 semi: true
 trailingComma: "es5"
-xmlWhitespaceSensitivity: "ignore"
+xmlWhitespaceSensitivity: "strict"


### PR DESCRIPTION
This was correctly updated in https://github.com/OCA/multi-company/pull/262 but reverted by mistake.

See https://github.com/OCA/multi-company/pull/262#discussion_r544084207.