### PR TITLE
[12.0][FIX] purchase_sale_inter_company - propagate correct uom to sol

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -149,6 +149,9 @@ class PurchaseOrder(models.Model):
         })
         for onchange_method in new_line._onchange_methods['product_id']:
             onchange_method(new_line)
+        new_line.update({
+            'product_uom': purchase_line.product_uom.id,
+        })
         return new_line._convert_to_write(new_line._cache)
 
     @api.multi


### PR DESCRIPTION
When `product_id_change()` is called, the new_line object is updated with the default product uom.

With this fix, after all onchanges methods calls, the product uom that was selected on `purchase.order.line` is assigned again and is correctly propagated.

The real culprit is `product_id_change()` in odoo's sale addon, I guess. It caclulates the price correctly with the selected uom, but at the end of the process overwrites the uom with product's default and therefore the prices is wrong according to the uom.

Here updates vals variable: [sale.py#L1526](https://github.com/odoo/odoo/blob/d9ea1d5f054f05197581acf67c8a9c1e6acb8d02/addons/sale/models/sale.py#L1526)

Here calculates price with the correct uom in the product objetc: [sale.py#L1548](https://github.com/odoo/odoo/blob/d9ea1d5f054f05197581acf67c8a9c1e6acb8d02/addons/sale/models/sale.py#L1548)

Here is "the mistake", and overwrites `vals` variable: [sale.py#L1549](https://github.com/odoo/odoo/blob/d9ea1d5f054f05197581acf67c8a9c1e6acb8d02/addons/sale/models/sale.py#L1549)