### PR TITLE
[IMP] purchase_sale_inter_company: set unit price in sales line and restrict updating unit price in already confirmed purchase line

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -167,6 +167,7 @@ class PurchaseOrder(models.Model):
         for onchange_method in new_line._onchange_methods["product_id"]:
             onchange_method(new_line)
         new_line.update({"product_uom": purchase_line.product_uom.id})
+        new_line.price_unit = purchase_line.price_unit
         return new_line._convert_to_write(new_line._cache)
 
     def button_cancel(self):

--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -16,13 +16,6 @@ class SaleOrder(models.Model):
         copy=False,
     )
 
-    def action_confirm(self):
-        for order in self.filtered("auto_purchase_order_id"):
-            for line in order.order_line.sudo():
-                if line.auto_purchase_line_id:
-                    line.auto_purchase_line_id.price_unit = line.price_unit
-        return super(SaleOrder, self).action_confirm()
-
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"


### PR DESCRIPTION
The price unit from origin purchase line should set on the new created sales line.

Ideally, the unit price in purchase order line which is already confirmed should not be updated. Because there is the chance of a vendor bill already drafted/validated.