### PR TITLE
[12.0] partner_multi_company: Force recompute visible_for_all_companies after installation

### DIFF
--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -16,6 +16,8 @@ def post_init_hook(cr, registry):
         'base.res_partner_rule',
         'res.partner',
     )
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['res.partner'].sudo().search([])._compute_visible_for_all_companies()
 
 
 def uninstall_hook(cr, registry):


### PR DESCRIPTION
Force recompute field visible_for_all_companies at installation, wasn't well target by the depends, so even if company_ids is auto filled, field wasn't compute back