### PR TITLE
[12.0] product_multi_company: Force recompute visible_for_all_companies after installation

### DIFF
--- a/product_multi_company/hooks.py
+++ b/product_multi_company/hooks.py
@@ -1,6 +1,8 @@
 # Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from odoo import api, SUPERUSER_ID
+
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -17,6 +19,8 @@ def post_init_hook(cr, registry):
         'product.product_comp_rule',
         'product.template',
     )
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['product.template'].sudo().search([])._compute_visible_for_all_companies()
 
 
 def uninstall_hook(cr, registry):


### PR DESCRIPTION
Force recompute field visible_for_all_companies at installation, wasn't well target by the depends, so even if company_ids is auto filled, field wasn't compute back