### PR TITLE
[FIX] partner_multi_company: reconciliation compatibility

### DIFF
--- a/partner_multi_company/__manifest__.py
+++ b/partner_multi_company/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Partner multi-company",
     "summary": "Select individually the partner visibility on each company",
-    "version": "12.0.1.0.1",
+    "version": "12.0.2.0.0",
     "license": "AGPL-3",
     "depends": [
         "base_multi_company",

--- a/partner_multi_company/migrations/12.0.2.0.0/pre-migration.py
+++ b/partner_multi_company/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Tecnativa - David Vidal
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """When this relation comes up in the reconciliation widget it we could run
+    into some nasty exeption due to how Odoo prepares the query, subtituting
+    and `res_partner` occurrence to the `p3` join alias, which a subquery won't
+    be aware of
+    odoo/odoo/blob/12.0/addons/account/models/reconciliation_widget.py#L103
+    So we rename the table and the column to avoid such errors.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        ALTER TABLE res_company_assignment_res_partner_rel
+        RENAME COLUMN res_partner_id TO partner_id
+        """
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        ALTER TABLE res_company_assignment_res_partner_rel
+        RENAME TO partner_res_company_assignment_rel
+        """
+    )

--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -17,6 +17,11 @@ class ResPartner(models.Model):
         store=True,
         index=True,
     )
+    company_ids = fields.Many2many(
+        relation="partner_res_company_assignment_rel",
+        column1="partner_id",
+        column2="res_company_assignment_id",
+    )
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
This line from the reconciliation widget
https://github.com/odoo/odoo/blob/12.0/addons/account/models/reconciliation_widget.py#L103
substitutes any occurrence of res_partner that could come in the
where_clause coming from ir_rules with the `p3` join alias of the
subsequent query.

In the case we've got a subselect, that alias won't make sense. So we're
preventing that situation renaming the table and the affected column
where such substitution was being made.

cc @Tecnativa TT30346

please review @pedrobaeza @carlosdauden 