### PR TITLE
[12.0][FIX] partner_multi_company CI tests fails

### DIFF
--- a/base_multi_company/hooks.py
+++ b/base_multi_company/hooks.py
@@ -29,8 +29,10 @@ def set_security_rule(env, rule_ref):
     rule = env.ref(rule_ref)
     if not rule:  # safeguard if it's deleted
         return
+    # We don't want to enable the rule if it isn't already active, as this leads
+    # to subsequent test fails in a CI context. This should be done via the core
+    # res.config.settings methods
     rule.write({
-        'active': True,
         'domain_force': (
             "['|', ('company_ids', 'in', user.company_id.ids),"
             " ('visible_for_all_companies', '=', True)]"

--- a/partner_multi_company/README.rst
+++ b/partner_multi_company/README.rst
@@ -41,6 +41,15 @@ template security rule. This only means that updating the module will not
 restore the security rule this module changes. Only a complete removal and
 reinstallation will serve.
 
+Configuration
+=============
+
+You need to enable multicompany contacts first. To do so:
+
+#. Go to *Settings > General Settings* and then to the *Multi-companies* section.
+#. If it isn't already enabled set *Multi-companies* on.
+#. Then, set *Common Contact Book* off if you wan't the access rules to be applied.
+
 Usage
 =====
 

--- a/partner_multi_company/readme/CONFIGURE.rst
+++ b/partner_multi_company/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+You need to enable multicompany contacts first. To do so:
+
+#. Go to *Settings > General Settings* and then to the *Multi-companies* section.
+#. If it isn't already enabled set *Multi-companies* on.
+#. Then, set *Common Contact Book* off if you wan't the access rules to be applied.

--- a/partner_multi_company/static/description/index.html
+++ b/partner_multi_company/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Partner multi-company</title>
 <style type="text/css">
 
@@ -374,13 +374,14 @@ of the partners.</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
-<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id4">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -392,20 +393,29 @@ template security rule. This only means that updating the module will not
 restore the security rule this module changes. Only a complete removal and
 reinstallation will serve.</p>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<p>You need to enable multicompany contacts first. To do so:</p>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; General Settings</em> and then to the <em>Multi-companies</em> section.</li>
+<li>If it isn’t already enabled set <em>Multi-companies</em> on.</li>
+<li>Then, set <em>Common Contact Book</em> off if you wan’t the access rules to be applied.</li>
+</ol>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id2">Usage</a></h1>
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
 <p>On the partner form view, go to the “Sales &amp; Purchases” tab, and put the
 companies in which you want to use that partner. If none is selected, the
 partner will be visible in all of them. The default value is the current one.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#id4">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Allow to select different companies from the parent in contacts.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/multi-company/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -413,15 +423,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id5">Credits</a></h1>
+<h1><a class="toc-backref" href="#id6">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id6">Authors</a></h2>
+<h2><a class="toc-backref" href="#id7">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
 <ul class="simple">
 <li>Oihane Crucelaegui &lt;<a class="reference external" href="mailto:oihanecruce&#64;gmail.com">oihanecruce&#64;gmail.com</a>&gt;</li>
 <li>Dave Lasley &lt;<a class="reference external" href="mailto:dave&#64;laslabs.com">dave&#64;laslabs.com</a>&gt;</li>
@@ -434,7 +444,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -56,6 +56,7 @@ class TestPartnerMultiCompany(common.SavepointCase):
         })
         cls.partner_company_1 = cls.partner_company_1.sudo(cls.user_company_1)
         cls.partner_company_2 = cls.partner_company_2.sudo(cls.user_company_2)
+        cls.env.ref("base.res_partner_rule").active = True
 
     def test_create_partner(self):
         partner = self.env['res.partner'].create({'name': 'Test'})

--- a/product_multi_company/README.rst
+++ b/product_multi_company/README.rst
@@ -40,6 +40,15 @@ template security rule. This only means that updating the module will not
 restore the security rule this module changes. Only a complete removal and
 reinstallation will serve.
 
+Configuration
+=============
+
+You need to enable multicompany products first. To do so:
+
+#. Go to *Settings > General Settings* and then to the *Multi-companies* section.
+#. If it isn't already enabled set *Multi-companies* on.
+#. Then, set *Common Product Catalog* off if you wan't the access rules to be applied.
+
 Usage
 =====
 

--- a/product_multi_company/readme/CONFIGURE.rst
+++ b/product_multi_company/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+You need to enable multicompany products first. To do so:
+
+#. Go to *Settings > General Settings* and then to the *Multi-companies* section.
+#. If it isn't already enabled set *Multi-companies* on.
+#. Then, set *Common Product Catalog* off if you wan't the access rules to be applied.

--- a/product_multi_company/static/description/index.html
+++ b/product_multi_company/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Product multi-company</title>
 <style type="text/css">
 
@@ -373,12 +373,13 @@ ul.auto-toc {
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
-<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -390,14 +391,23 @@ template security rule. This only means that updating the module will not
 restore the security rule this module changes. Only a complete removal and
 reinstallation will serve.</p>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<p>You need to enable multicompany products first. To do so:</p>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; General Settings</em> and then to the <em>Multi-companies</em> section.</li>
+<li>If it isn’t already enabled set <em>Multi-companies</em> on.</li>
+<li>Then, set <em>Common Product Catalog</em> off if you wan’t the access rules to be applied.</li>
+</ol>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id2">Usage</a></h1>
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
 <p>On the product form view, go to the “Information” tab, and put the companies
 in which you want to use that product. If none is selected, the product will
 be visible in all of them. The default value is the current one.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/multi-company/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -405,15 +415,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;tecnativa.com">pedro.baeza&#64;tecnativa.com</a>&gt;</li>
 <li>Dave Lasley &lt;<a class="reference external" href="mailto:dave&#64;laslabs.com">dave&#64;laslabs.com</a>&gt;</li>
@@ -424,7 +434,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -56,6 +56,7 @@ class TestProductMultiCompany(common.TransactionCase):
                  (6, 0, self.group_user.ids)],
              'company_id': self.company_2.id,
              'company_ids': [(6, 0, self.company_2.ids)]})
+        self.env.ref("product.product_comp_rule").active = True
 
     def test_create_product(self):
         product = self.env['product.product'].create({'name': 'Test'})


### PR DESCRIPTION
If we enable the multicompany rules, some subsequent tests will fail
unexpectedly if they are designed for a shared contacts environment. So
we relay on the rewritten rule current value and don't enable it until
the user does it via res.config.settings (Common Contact Book).

cc @Tecnativa TT23741

cc @pedrobaeza @carlosdauden 