### PR TITLE
[14.0] intercompany_shared_contact: add

### DIFF
--- a/intercompany_shared_contact/__init__.py
+++ b/intercompany_shared_contact/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/intercompany_shared_contact/__manifest__.py
+++ b/intercompany_shared_contact/__manifest__.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Intercompany shared contact",
+    "summary": (
+        "User of each company are contact of a company partner.\n"
+        "All child address of a company are automatically shared"
+    ),
+    "version": "14.0.1.0.0",
+    "category": "Partner",
+    "website": "https://github.com/OCA/multi-company",
+    "author": "Odoo Community Association (OCA), " "Akretion",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "contacts",
+    ],
+    "data": [
+        "views/res_partner_view.xml",
+        "views/res_users_view.xml",
+        "security/ir_rule.xml",
+    ],
+    "demo": [],
+}

--- a/intercompany_shared_contact/models/__init__.py
+++ b/intercompany_shared_contact/models/__init__.py
@@ -1,0 +1,3 @@
+from . import res_users
+from . import res_partner
+from . import res_company

--- a/intercompany_shared_contact/models/res_company.py
+++ b/intercompany_shared_contact/models/res_company.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    _sql_constraints = [
+        (
+            "partner_uniq",
+            "unique (partner_id)",
+            "The company partner_id must be unique !",
+        )
+    ]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        self = self.with_context(creating_res_company=True)
+        return super().create(vals_list).with_context(creating_res_company=False)

--- a/intercompany_shared_contact/models/res_partner.py
+++ b/intercompany_shared_contact/models/res_partner.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    res_company_id = fields.One2many(
+        "res.company",
+        "partner_id",
+        readonly=True,
+        help="Effectively a One2one field to represent the corresponding res.company",
+    )
+    origin_company_id = fields.Many2one(
+        "res.company",
+        compute="_compute_origin_company_id",
+        store=True,
+        help="Hack field to keep the information of the 'real' company_id. "
+        "That way, we can share the contact by setting company_id to null, "
+        "without losing any information. If null, the contact is not shared.",
+    )
+
+    @api.depends("res_company_id", "parent_id.origin_company_id")
+    def _compute_origin_company_id(self):
+        for record in self:
+            if record.parent_id.origin_company_id:
+                record.origin_company_id = record.parent_id.origin_company_id
+                record.company_id = False
+            if record.res_company_id:
+                record.origin_company_id = record.res_company_id
+                record.company_id = False
+            else:
+                record.origin_company_id = False
+
+    # super().sudo().create() has some interaction that loops infinitely,
+    # thus the switch with multiple sudo() calls
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if self.env.context.get("creating_res_company"):
+            self = self.sudo()
+        result = super().create(vals_list)
+        self = self.sudo(False)
+        return result
+
+    @api.model
+    def write(self, vals):
+        if self.env.context.get("creating_res_company"):
+            self = self.sudo()
+        result = super().write(vals)
+        self = self.sudo(False)
+        return result

--- a/intercompany_shared_contact/models/res_users.py
+++ b/intercompany_shared_contact/models/res_users.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    @api.onchange("company_id")
+    def onchange_company_id(self):
+        self._sync_parent_company()
+
+    def _sync_parent_company(self):
+        partner_companies = self.env["res.company"].sudo().search([]).partner_id
+        for record in self:
+            # Note if we manually affect a user to a company (res.partner)
+            # that is not an address of a company (res.company)
+            # it's maybe an "external" user that do not belong to a specific company
+            # So we do not update in this case
+            # For example, you can have Akretion user attached to the res.partner
+            # Akretion, and this partner is not an address of a company
+            if not record.parent_id or record.parent_id in partner_companies:
+                record.parent_id = record.company_id.partner_id
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._sync_parent_company()
+        return records
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "company_id" in vals:
+            self._sync_parent_company()
+        return res

--- a/intercompany_shared_contact/readme/CONTRIBUTORS.rst
+++ b/intercompany_shared_contact/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Sébastien Beau <sebastien.beau@akretion.com>
+* Kevin Khao <kevin.khao@akretion.com

--- a/intercompany_shared_contact/readme/DESCRIPTION.rst
+++ b/intercompany_shared_contact/readme/DESCRIPTION.rst
@@ -1,0 +1,8 @@
+This module automatically shares all the contacts originating from companies (res.company object).
+
+For example, suppose we have a multi-company environment with two companies (res.company) A and B in Odoo.
+We have users uA, uB (belonging to their respective companies).
+
+Normally, uA cannot access the contact B.
+With this module, uA can see B (and inversely uB can see A).
+uA still can't see all the other (supplier/reseller) contacts of company B.

--- a/intercompany_shared_contact/readme/ROADMAP.rst
+++ b/intercompany_shared_contact/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+Instead of sharing all company contacts by default, it should be possible to selectively do so for example
+with a flag on res.company.

--- a/intercompany_shared_contact/security/ir_rule.xml
+++ b/intercompany_shared_contact/security/ir_rule.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data noupdate="1">
+        <record model="ir.rule" id="intercompany_share_contact">
+            <field
+                name="name"
+            >Intercompany contact: contact must be shared or part of user's</field>
+            <field name="model_id" ref="base.model_res_partner" />
+            <field name="perm_read" eval="False" />
+            <field name="perm_create" eval="True" />
+            <field name="perm_write" eval="True" />
+            <field name="perm_unlink" eval="True" />
+            <field name="domain_force">[
+                '|', ('origin_company_id', '=', False), ('origin_company_id', 'in', company_ids),
+            ]</field>
+        </record>
+    </data>
+</odoo>

--- a/intercompany_shared_contact/tests/__init__.py
+++ b/intercompany_shared_contact/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_shared_contacts

--- a/intercompany_shared_contact/tests/test_shared_contacts.py
+++ b/intercompany_shared_contact/tests/test_shared_contacts.py
@@ -1,0 +1,63 @@
+#  Copyright (c) Akretion 2021
+#  License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo.exceptions import AccessError
+from odoo.tests import SavepointCase
+
+
+class IntercompanySharedContactCase(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_x = cls.env["res.company"].create({"name": "x Company"})
+        cls.partner_x = cls.company_x.partner_id
+        cls.user_x = cls.env["res.users"].create(
+            {
+                "name": "x user",
+                "company_ids": [cls.company_x.id],
+                "company_id": cls.company_x.id,
+                "login": "x",
+            }
+        )
+
+        cls.company_y = cls.env["res.company"].create({"name": "y Company"})
+        cls.partner_y = cls.company_y.partner_id
+        cls.user_y = cls.env["res.users"].create(
+            {
+                "name": "y user",
+                "company_ids": [cls.company_y.id],
+                "company_id": cls.company_y.id,
+                "login": "y",
+            }
+        )
+
+        cls.partner_other = cls.env.ref("base.res_partner_12")
+        cls.partner_other.company_id = cls.company_x
+
+    def test_computed_fields(self):
+        self.assertEqual(self.partner_x.res_company_id, self.company_x)
+        self.assertEqual(self.partner_x.origin_company_id, self.company_x)
+
+    def test_intercompany_read(self):
+        """
+        Company contacts are readable by other companies
+        """
+        self.env["res.partner"].with_user(self.user_x).browse(self.partner_y.id).name
+        self.env["res.partner"].with_user(self.user_y).browse(self.partner_x.id).name
+
+    def test_intercompany_update(self):
+        """
+        Company contacts are non-modifiable by other companies
+        """
+        partner_y = self.partner_y.with_user(self.user_x)
+        with self.assertRaises(AccessError):
+            partner_y.name = "boom"
+
+    def test_intercompany_other(self):
+        """
+        Private, non-company-linked contacts are not shared
+        """
+        self.partner_other.company_id = self.company_x
+        self.partner_other.invalidate_cache()
+        with self.assertRaises(AccessError):
+            self.partner_other.with_user(self.user_y).name

--- a/intercompany_shared_contact/views/res_partner_view.xml
+++ b/intercompany_shared_contact/views/res_partner_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//group[@name='misc']//field[@name='company_id']"
+                position="after"
+            >
+                <field
+                    name="origin_company_id"
+                    attrs="{'invisible': [('origin_company_id', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/intercompany_shared_contact/views/res_users_view.xml
+++ b/intercompany_shared_contact/views/res_users_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_users_form" model="ir.ui.view">
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='access_rights']/group/field[@name='company_id']"
+                position="after"
+            >
+                <field name="parent_id" string="Contact of Company" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/intercompany_shared_contact/odoo/addons/intercompany_shared_contact
+++ b/setup/intercompany_shared_contact/odoo/addons/intercompany_shared_contact
@@ -1,0 +1,1 @@
+../../../../intercompany_shared_contact

--- a/setup/intercompany_shared_contact/setup.py
+++ b/setup/intercompany_shared_contact/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module automatically shares all the contacts originating from companies (res.company object).

For example, suppose we have a multi-company environment with two companies (res.company) A and B in Odoo.
We have users uA, uB (belonging to their respective companies).

Normally, uA cannot access the contact B.
With this module, uA can see B (and inversely uB can see A).
uA still can't see all the other (supplier/reseller) contacts of company B.