### PR TITLE
[13.0][FIX] account_invoice_inter_company: post method

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -30,9 +30,9 @@ class AccountMove(models.Model):
         )
         return company or False
 
-    def action_post(self):
+    def post(self):
         """ Validated invoice generate cross invoice base on company rules """
-        res = super().action_post()
+        res = super().post()
         # Intercompany account entries or receipts aren't supported
         supported_types = {"out_invoice", "in_invoice", "out_refund", "in_refund"}
         for src_invoice in self.filtered(lambda x: x.type in supported_types):


### PR DESCRIPTION
If the invoice is validated skipping the `action_post` method by a third
module we could miss the inter company creation. So we want to ensure it
overriding the inner method.

cc @Tecnativa TT30553

please review @carlosdauden @pedrobaeza 