### PR TITLE
[13.0][purchase_sale_inter_company] fix purchase line link with vendor bill

### DIFF
--- a/purchase_sale_inter_company/models/account_move.py
+++ b/purchase_sale_inter_company/models/account_move.py
@@ -9,12 +9,9 @@ from odoo import _, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def inter_company_create_invoice(
-        self, dest_company, dest_inv_type, dest_journal_type
-    ):
-        res = super().inter_company_create_invoice(
-            dest_company, dest_inv_type, dest_journal_type
-        )
+    def _inter_company_create_invoice(self, dest_company):
+        res = super()._inter_company_create_invoice(dest_company)
+        dest_inv_type = self._get_destination_invoice_type()
         if dest_inv_type == "in_invoice":
             # Link intercompany purchase order with intercompany invoice
             self._link_invoice_purchase(res["dest_invoice"])
@@ -24,8 +21,6 @@ class AccountMove(models.Model):
         self.ensure_one()
         orders = self.env["purchase.order"]
         vals = {}
-        if dest_invoice.state not in ["draft", "cancel"]:
-            vals["invoiced"] = True
         for line in dest_invoice.invoice_line_ids:
             vals["invoice_lines"] = [(4, line.id)]
             purchase_lines = line.auto_invoice_line_id.sale_line_ids.mapped(

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -233,12 +233,17 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         sale_invoice_id = sales._create_invoices()[0]
         sale_invoice_id.action_post()
         self.assertEquals(
-            sale_invoice_id.auto_invoice_id, self.purchase_company_a.invoice_ids,
+            self.purchase_company_a.invoice_ids.auto_invoice_id, sale_invoice_id
         )
         self.assertEquals(
-            sale_invoice_id.auto_invoice_id.invoice_line_ids,
+            self.purchase_company_a.invoice_ids.invoice_line_ids,
             self.purchase_company_a.order_line.invoice_lines,
         )
+        po_lines = self.purchase_company_a.invoice_ids.mapped(
+            "invoice_line_ids.purchase_line_id"
+        )
+        for ol in self.purchase_company_a.order_line:
+            self.assertIn(ol, po_lines)
 
     def test_cancel(self):
         self.company_b.sale_auto_validation = False


### PR DESCRIPTION
The method had not been correctly migrated, and as a consequence the vendor bills were not being linked with the POs