### PR TITLE
[13.0][purchase_sale_inter_company] Incoming Shipment Auto Validation

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -188,6 +188,11 @@ class AccountMove(models.Model):
         dest_invoice_data.invoice_date = self.invoice_date
         dest_invoice_data.narration = self.narration
         dest_invoice_data.currency_id = self.currency_id
+        # The extract_state field is introduced by module
+        # 'account_invoice_extract' of Odoo Enterprise. The same
+        # is done in module account_facturx.
+        if "extract_state" in self:
+            dest_invoice_data.extract_state = "done"
         vals = dest_invoice_data._values_to_save(all_fields=True)
         vals.update(
             {

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -60,9 +60,9 @@ class AccountMove(models.Model):
         if dest_user:
             for line in self.invoice_line_ids:
                 try:
-                    line.sudo(False).product_id.product_tmpl_id.with_user(
-                        dest_user
-                    ).check_access_rule("read")
+                    line.sudo(False).product_id.product_tmpl_id.with_context(
+                        allowed_company_ids=dest_company.ids
+                    ).with_user(dest_user).check_access_rule("read")
                 except AccessError:
                     raise UserError(
                         _(

--- a/purchase_sale_inter_company/models/account_move.py
+++ b/purchase_sale_inter_company/models/account_move.py
@@ -9,12 +9,9 @@ from odoo import _, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def inter_company_create_invoice(
-        self, dest_company, dest_inv_type, dest_journal_type
-    ):
-        res = super().inter_company_create_invoice(
-            dest_company, dest_inv_type, dest_journal_type
-        )
+    def _inter_company_create_invoice(self, dest_company):
+        res = super()._inter_company_create_invoice(dest_company)
+        dest_inv_type = self._get_destination_invoice_type()
         if dest_inv_type == "in_invoice":
             # Link intercompany purchase order with intercompany invoice
             self._link_invoice_purchase(res["dest_invoice"])
@@ -24,8 +21,6 @@ class AccountMove(models.Model):
         self.ensure_one()
         orders = self.env["purchase.order"]
         vals = {}
-        if dest_invoice.state not in ["draft", "cancel"]:
-            vals["invoiced"] = True
         for line in dest_invoice.invoice_line_ids:
             vals["invoice_lines"] = [(4, line.id)]
             purchase_lines = line.auto_invoice_line_id.sale_line_ids.mapped(

--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -59,6 +59,11 @@ class PurchaseOrder(models.Model):
             :rtype dest_company : res.company record
         """
         self.ensure_one()
+        self = self.with_context(
+            force_company=dest_company.id,
+            company_id=dest_company.id,
+            allowed_company_ids=dest_company.ids,
+        )
         # Check intercompany user
         intercompany_user = dest_company.intercompany_sale_user_id
         if not intercompany_user:

--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -33,3 +33,8 @@ class ResCompany(models.Model):
         string="Intercompany Sale User",
         old_name="intercompany_user_id",
     )
+    incoming_shipment_auto_validation = fields.Boolean(
+        string="Incoming Shipment Auto Validation",
+        help="When the delivery order is validated, the incoming shipment "
+        "will be automtically validated.",
+    )

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -41,3 +41,10 @@ class InterCompanyRulesConfig(models.TransientModel):
         "order in another company.",
         readonly=False,
     )
+    incoming_shipment_auto_validation = fields.Boolean(
+        related="company_id.incoming_shipment_auto_validation",
+        string="Incoming Shipment Auto Validation",
+        help="When the delivery order is validated, the incoming shipment "
+        "will be automtically validated.",
+        readonly=False,
+    )

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -21,6 +21,13 @@ class StockPicking(models.Model):
             if not purchase:
                 continue
             purchase.picking_ids.write({"intercompany_picking_id": pick.id})
+            if (
+                purchase.picking_ids
+                and not purchase.picking_ids[
+                    0
+                ].company_id.incoming_shipment_auto_validation
+            ):
+                continue
             for move_line in pick.move_line_ids:
                 qty_done = move_line.qty_done
                 sale_line_id = move_line.move_id.sale_line_id

--- a/purchase_sale_inter_company/readme/CONFIGURE.rst
+++ b/purchase_sale_inter_company/readme/CONFIGURE.rst
@@ -1,0 +1,7 @@
+To configure this module, you need to:
+#. go to the menu *Settings > Companies > Companies*.
+#. Select one of the companies.
+#. Go to the tab *Inter-Company* then the group *Purchase To Sale*.
+#. Select the *Warehouse For Sale Orders*, it is the warehouse that will be used to automatically generate the sale order in the other company.
+#. If you check the option *Sale Auto Validation* in the configuration of company B, then when you validate a *Purchase Order* in company A with company B as supplier, the *Sale Order* will be automatically validated in company B with company A as customer.
+#. If you check the option *Incoming Shipment Auto Validation* in the configuration of company B, then when you validate the *Delivery Order* in company A, the corresponding *Incoming Shipment* will be automatically validated in company B.

--- a/purchase_sale_inter_company/readme/CONTRIBUTORS.rst
+++ b/purchase_sale_inter_company/readme/CONTRIBUTORS.rst
@@ -1,0 +1,12 @@
+* Odoo S.A.
+* Chafique Delli <chafique.delli@akretion.com>
+* Alexis de Lattre <alexis.delattre@akretion.com>
+* Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Carlos Dauden
+  * Jairo Llopis
+* Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
+* `ForgeFlow <https://www.forgeflow.com>`_:
+
+  * Jordi Ballester <jordi.ballester@forgeflow.com>

--- a/purchase_sale_inter_company/readme/DESCRIPTION.rst
+++ b/purchase_sale_inter_company/readme/DESCRIPTION.rst
@@ -1,0 +1,8 @@
+This module is useful if there are multiple companies in the same Odoo database and those companies sell goods or services among themselves.
+It allows to create a sale order in company A from a purchase order in company B.
+
+Imagine you have company A and company B in the same Odoo database:
+
+* Company A purchase goods from company B.
+* Company A will create a purchase order with company B as supplier.
+* This module automate the creation of the sale order in company B with company A as customer.

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -233,12 +233,17 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         sale_invoice_id = sales._create_invoices()[0]
         sale_invoice_id.action_post()
         self.assertEquals(
-            sale_invoice_id.auto_invoice_id, self.purchase_company_a.invoice_ids,
+            self.purchase_company_a.invoice_ids.auto_invoice_id, sale_invoice_id
         )
         self.assertEquals(
-            sale_invoice_id.auto_invoice_id.invoice_line_ids,
+            self.purchase_company_a.invoice_ids.invoice_line_ids,
             self.purchase_company_a.order_line.invoice_lines,
         )
+        po_lines = self.purchase_company_a.invoice_ids.mapped(
+            "invoice_line_ids.purchase_line_id"
+        )
+        for ol in self.purchase_company_a.order_line:
+            self.assertIn(ol, po_lines)
 
     def test_cancel(self):
         self.company_b.sale_auto_validation = False

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -57,9 +57,10 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         )
         cls.company_a.warehouse_id = cls.warehouse_company_a
         cls.company_a.sale_auto_validation = 1
+        cls.company_a.incoming_shipment_auto_validation = True
         cls.company_b.warehouse_id = cls.warehouse_company_b
         cls.company_b.sale_auto_validation = 1
-
+        cls.company_b.incoming_shipment_auto_validation = True
         cls.user_company_a.group_ids = [
             (
                 6,

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -24,6 +24,7 @@
                         for="so_from_po"
                     />
                 </div>
+
                 <div
                     id="inter_company_warehouse"
                     attrs="{'invisible':['|', ('company_id', '=', False), ('so_from_po', '=', False)]}"
@@ -44,6 +45,12 @@
                     <br />
                     <field name="sale_auto_validation" class="oe_inline" />
                     <label for="sale_auto_validation" class="oe_inline o_light_label" />
+                    <br />
+                    <field name="incoming_shipment_auto_validation" class="oe_inline" />
+                    <label
+                        for="incoming_shipment_auto_validation"
+                        class="oe_inline o_light_label"
+                    />
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Before, when you completed a delivery order in company A this would automatically validate the incoming shipment in company B.
This PR introduces a parameter in the configuration 'Incoming Shipment Auto Validation' that allows you to choose if you want this behavior. Otherwise the incoming shipment needs to be manually validated.

This manual validation makes sense when the two warehouses are managed by different people, and you want to actually track the actual receipt of the goods to the destination warehouse.

cc @JoanSForgeFlow 