### PR TITLE
[12.0][FIX] account_invoice_inter_company: avoid issue writing the company_id

### DIFF
--- a/account_invoice_inter_company/views/account_invoice_views.xml
+++ b/account_invoice_inter_company/views/account_invoice_views.xml
@@ -6,6 +6,10 @@
         <field name="inherit_id" ref="account.invoice_supplier_form"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <!-- Enforce this to avoid issues writing the company_id-->
+            <xpath expr="//field[@name='invoice_line_ids']/tree" position="attributes">
+                <attribute name="editable">bottom</attribute>
+            </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='company_id']" position="attributes">
                 <attribute name="readonly">0</attribute>
             </xpath>


### PR DESCRIPTION
This PR intends to fix an issue in Travis (https://github.com/OCA/multi-company/pull/305) making fail the tests when the module account_bill_line_distribution is installed.

![image](https://user-images.githubusercontent.com/44768500/131967450-a3dc974f-e882-40b6-acc3-ba76ef043175.png)

cc ~ @ForgeFlow