### PR TITLE
[13.0][FIX] account_multicompany_easy_creation: Fix tests if l10n es previously installed.

### DIFF
--- a/account_multicompany_easy_creation/tests/test_easy_creation.py
+++ b/account_multicompany_easy_creation/tests/test_easy_creation.py
@@ -9,9 +9,7 @@ class TestEasyCreation(common.SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.user = cls.env.ref("base.user_admin")
-        cls.chart_template_id = cls.env.ref(
-            "l10n_generic_coa.configurable_chart_template"
-        )
+        cls.chart_template_id = cls.env["account.chart.template"].search([], limit=1)
 
     def _test_model_items(self, model, company_id):
         self.assertGreaterEqual(

--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
@@ -169,13 +169,12 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
         self.create_bank_journals()
         self.create_sequences()
 
-    @ormcache("self.id", "company_id", "match_tax_ids")
-    def taxes_by_company(self, company_id, match_tax_ids):
+    @ormcache("self.id", "company_id", "match_taxes")
+    def taxes_by_company(self, company_id, match_taxes):
         AccountTax = self.env["account.tax"].sudo()
-        account_taxes = AccountTax.browse(match_tax_ids)
         return AccountTax.search(
             [
-                ("description", "in", account_taxes.mapped("description")),
+                ("description", "in", match_taxes.mapped("description")),
                 ("company_id", "=", company_id),
             ]
         ).ids
@@ -185,7 +184,7 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
             lambda tax: tax.company_id == company_from
         )
         tax_ids = product_taxes and self.taxes_by_company(
-            self.new_company_id.id, product_taxes.ids
+            self.new_company_id.id, product_taxes
         )
         if tax_ids:
             product.update({taxes_field: [(4, tax_id) for tax_id in tax_ids]})


### PR DESCRIPTION
Related to: https://github.com/OCA/multi-company/pull/317

Error in some cases: `ValueError: External ID not found in the system: l10n_generic_coa.configurable_chart_template`

**Steps to reproduce the error previously**:
- Install `l10n_es`
- Install `account_multicompany_easy_creation`
- Run the tests.

**Reasons**:
When `account_multicompany_easy_creation` is installed in the first place, `l10n_generic_coa` is self-installed and everything works correctly, but if we have previously installed `l10n_es`, `l10n_generic_coa` will no longer be installed which caused the error of not being able to load that accounting template.

Additionally, a cache problem that appeared in some cases is solved (install l10n_es + account_multicompany_easy_creation + run tests).

Please @pedrobaeza can you review it?

@Tecnativa TT32209