### PR TITLE
[12.0] FIX account_invoice_inter_company when creating supplier refund in destination company

### DIFF
--- a/account_invoice_inter_company/models/account_invoice.py
+++ b/account_invoice_inter_company/models/account_invoice.py
@@ -174,6 +174,7 @@ class AccountInvoice(models.Model):
         dest_invoice_data = Form(
             self.env['account.invoice'].with_context(
                 default_type=dest_inv_type,
+                default_company_id=dest_company.id,
                 force_company=dest_company.id
             ))
         dest_invoice_data.company_id = dest_company


### PR DESCRIPTION

Without this, the default value for "partner_bank_id" in the new invoice would be populated with a bank of the source company, raising ValidationError later