### PR TITLE
[14.0][FIX] account_invoice_inter_company: Delete default_journal_id if present

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -4,6 +4,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, UserError
 from odoo.tests.common import Form
 from odoo.tools import float_compare
+from odoo.tools.misc import clean_context
 
 
 class AccountMove(models.Model):
@@ -163,6 +164,7 @@ class AccountMove(models.Model):
         :rtype dest_company : res.company record
         """
         self.ensure_one()
+        self = self.with_context(clean_context(self.env.context))
         dest_inv_type = self._get_destination_invoice_type()
         dest_journal_type = self._get_destination_journal_type()
         # find the correct journal


### PR DESCRIPTION
Hi,

If you create an inter-company invoice from a journal's card in Accounting dashboard, the key "default_journal_id" with the journal clicked reaches up creation of the invoice in the other company, showing the error "Cannot create an invoice of type %(move_type)s with a journal having %(journal_type)s as type." raised by "_get_default_journal".

Regards