### PR TITLE
[14.0][FIX] fix creating refund in multi-company

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -31,9 +31,9 @@ class AccountMove(models.Model):
         )
         return company or False
 
-    def action_post(self):
+    def _post(self, soft=True):
         """Validated invoice generate cross invoice base on company rules"""
-        res = super().action_post()
+        res = super()._post(soft=soft)
         # Intercompany account entries or receipts aren't supported
         supported_types = {"out_invoice", "in_invoice", "out_refund", "in_refund"}
         for src_invoice in self.filtered(lambda x: x.move_type in supported_types):


### PR DESCRIPTION
Creating a refund from the wizard with a full refund is not propagated to the destination company

@bealdav @PierrickBrun @Kev-Roche @pedrobaeza 