### PR TITLE
[FIX] fix synchronisation of commercial field

### DIFF
--- a/intercompany_shared_contact/models/res_partner.py
+++ b/intercompany_shared_contact/models/res_partner.py
@@ -70,3 +70,6 @@ class ResPartner(models.Model):
                         % fields_name
                     )
         return res
+
+    def _commercial_sync_to_children(self):
+        return super(ResPartner, self.sudo())._commercial_sync_to_children()

--- a/intercompany_shared_contact/models/res_users.py
+++ b/intercompany_shared_contact/models/res_users.py
@@ -21,7 +21,7 @@ class ResUsers(models.Model):
             # So we do not update in this case
             # For example, you can have Akretion user attached to the res.partner
             # Akretion, and this partner is not an address of a company
-            if not record.parent_id or record.parent_id in partner_companies:
+            if not record.parent_id or record.parent_id not in partner_companies:
                 record.parent_id = record.company_id.partner_id
 
     @api.model_create_multi

--- a/intercompany_shared_contact/tests/models.py
+++ b/intercompany_shared_contact/tests/models.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    foo_company_dependent_field = fields.Char(company_dependent=True)
+
+    @api.model
+    def _commercial_fields(self):
+        self.check_access_rule("write")
+        return super()._commercial_fields() + ["foo_company_dependent_field"]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-test-helper>=1.1.0


### PR DESCRIPTION
Company dependent field can be synchronized to children, if the child is a partner related to a user
we need to do the sync with sudo to avoid user error (as current user do not have access right on res.user).