### PR TITLE
[IMP] purchase_sale_inter_company: Created purchase order ships to location owned by sale order's shipping address

### DIFF
--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -144,9 +144,16 @@ class SaleOrder(models.Model):
         if self.note:
             new_order.notes = self.note
         if 'picking_type_id' in new_order:
-            new_order.picking_type_id = (
-                dest_company.po_picking_type_id.warehouse_id.company_id ==
-                dest_company and dest_company.po_picking_type_id or False)
+            picking_type_dest_owned = self.env['stock.picking.type'].search([
+                ('default_location_dest_id.partner_id', '=',
+                 self.partner_shipping_id.id),
+            ], limit=1)
+            if picking_type_dest_owned:
+                new_order.picking_type_id = picking_type_dest_owned
+            else:
+                new_order.picking_type_id = (
+                    dest_company.po_picking_type_id.warehouse_id.company_id ==
+                    dest_company and dest_company.po_picking_type_id or False)
         return new_order._convert_to_write(new_order._cache)
 
     @api.model


### PR DESCRIPTION
**Steps** (same as added test)

0. Set up everything so that creating a sale order from Company B triggers a purchase order in Company A
1. [In Company A] Create a location owned by **partner**
2. [In Company A] Create an internal picking type having the created location as default destination
3. [In Company B] Create a sale order selling to Company A, shipping to **partner**

**Actual behavior**
The purchase order created in Company A has the picking type defined in Company A's "Picking type for Purchase Orders" (`po_picking_type_id`)

**Desired behavior**
The purchase order created in Company A has created picking type.
