### PR TITLE
[FIX][14.0][account_multicompany_easy_creation] Fixing website URL

### DIFF
--- a/account_multicompany_easy_creation/__manifest__.py
+++ b/account_multicompany_easy_creation/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "This module adds a wizard to create companies easily",
     "version": "14.0.1.0.0",
     "category": "Multicompany",
-    "website": "https://github.com/OCA/multi-company"
+    "website": "https://github.com/OCA/multi-company/"
     "account_multicompany_easy_creation",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",


### PR DESCRIPTION
Missing one '/'

Actually the URL is https://github.com/OCA/multi-companyaccount_multicompany_easy_creation which fails