### PR TITLE
[14.0][IMP] base_multi_company: Don't set default on company_ids

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -19,7 +19,6 @@ class MultiCompanyAbstract(models.AbstractModel):
     company_ids = fields.Many2many(
         string="Companies",
         comodel_name="res.company",
-        default=lambda self: self._default_company_ids(),
     )
     # TODO: Remove it following https://github.com/odoo/odoo/pull/81344
     no_company_ids = fields.Boolean(
@@ -37,9 +36,6 @@ class MultiCompanyAbstract(models.AbstractModel):
                 record.no_company_ids = False
             else:
                 record.no_company_ids = True
-
-    def _default_company_ids(self):
-        return self.browse(self.env.company.ids)
 
     @api.depends("company_ids")
     @api.depends_context("company")

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -192,6 +192,41 @@ class TestMultiCompanyAbstract(common.SavepointCase):
         # Check if all companies have been added
         self.assertEqual(tester.sudo().company_ids, companies)
 
+    def test_company_id_create_false(self):
+        """
+        Test a creation with only company_id == False
+        """
+
+        user_obj = self.env["res.users"]
+        company_obj = self.env["res.company"]
+        company1 = self.env.ref("base.main_company")
+        # Create companies
+        company2 = company_obj.create({"name": "High salaries"})
+        company3 = company_obj.create({"name": "High salaries, twice more!"})
+        companies = company1 + company2 + company3
+        # Create a "normal" user (not the admin)
+        user = user_obj.create(
+            {
+                "name": "Best employee",
+                "login": "best-emplyee@example.com",
+                "company_id": company1.id,
+                "company_ids": [(6, False, companies.ids)],
+            }
+        )
+        tester_obj = self.test_model.with_user(user)
+        # We add both values
+        tester = tester_obj.create(
+            {
+                "name": "My tester",
+                "company_id": False,
+            }
+        )
+        # Check company_ids is False too
+        self.assertFalse(tester.sudo().company_ids)
+
+        # Check company_id is False also when changing current one
+        self.assertFalse(tester.with_company(company2).company_id)
+
     def test_set_company_id(self):
         """
         Test object creation with both company_ids and company_id

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -11,8 +11,7 @@ from .common import ProductMultiCompanyCommon
 class TestProductMultiCompany(ProductMultiCompanyCommon, common.SavepointCase):
     def test_create_product(self):
         product = self.env["product.product"].create({"name": "Test"})
-        company = self.env.company
-        self.assertTrue(company.id in product.company_ids.ids)
+        self.assertFalse(product.company_ids)
 
     def test_company_none(self):
         self.assertFalse(self.product_company_none.company_id)


### PR DESCRIPTION
As company_ids field is not required and as company_ids can be void (record
can be accessed through all companies), no default should be set.