### PR TITLE
[14.0][FIX] purchase_sale_inter_company: fix new sale date_order

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -127,7 +127,7 @@ class PurchaseOrder(models.Model):
                 "company_id": dest_company.id,
                 "client_order_ref": name,
                 "partner_id": partner.id,
-                "date_order": self.date_order,
+                "date_order": self.date_approve,
                 "auto_purchase_order_id": self.id,
             }
         )


### PR DESCRIPTION
The sale order_date actually is the purchase order date creation. This fix puts the sale order date as the purchase validation date (date_approve of po)
