### PR TITLE
[12.0][IMP] purchase_sale_inter_company: Sync picking option

### DIFF
--- a/purchase_sale_inter_company/__init__.py
+++ b/purchase_sale_inter_company/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/purchase_sale_inter_company/__manifest__.py
+++ b/purchase_sale_inter_company/__manifest__.py
@@ -23,5 +23,6 @@
     ],
     'data': [
         'views/res_config_view.xml',
+        'wizard/stock_backorder_confirmation_views.xml',
     ],
 }

--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -55,3 +55,8 @@ class ResCompany(models.Model):
         comodel_name='res.users',
         string='Intercompany User',
     )
+    sync_picking = fields.Boolean(
+        string='Sync the receipt with the delivery',
+        help='Sync the receipt from the destination company with the '
+        'delivery from the source company',
+    )

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -72,3 +72,10 @@ class InterCompanyRulesConfig(models.TransientModel):
         string='Intercompany User',
         readonly=False,
     )
+    sync_picking = fields.Boolean(
+        related='company_id.sync_picking',
+        string='Sync the receipt from the destination company with the delivery',
+        help='Sync the receipt from the destination company with '
+        'the delivery from the source company',
+        readonly=False,
+    )

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -142,15 +142,14 @@ class StockPicking(models.Model):
                 dest_picking.action_confirm()
 
     def check_all_done(self, picking):
-        qty_done = sum(picking.mapped(
-            "move_ids_without_package.quantity_done"
+        picking_lines = picking.move_ids_without_package.filtered(
+            lambda l: l.state != "cancel"
+        )
+        qty_done = sum(picking_lines.mapped("quantity_done"))
+        reserved = sum(picking_lines.mapped(
+            "reserved_availability"
         ))
-        reserved = sum(picking.mapped(
-            "move_ids_without_package.reserved_availability"
-        ))
-        available = sum(picking.mapped(
-            "move_ids_without_package.product_uom_qty"
-        ))
+        available = sum(picking_lines.mapped("product_uom_qty"))
         if qty_done == 0.0 and reserved == available:
             return True
         return False

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -9,7 +9,7 @@ from odoo.exceptions import UserError
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    intercompany_picking_id = fields.Many2one(comodel_name='stock.picking')
+    intercompany_picking_id = fields.Many2one(comodel_name='stock.picking', copy=False)
 
     @api.multi
     def do_transfer(self):
@@ -46,3 +46,129 @@ class StockPicking(models.Model):
                 force_company=po_pick.company_id.id,
             ).action_done()
         return super(StockPicking, self).do_transfer()
+
+    def button_validate(self):
+        is_intercompany = self.env["res.company"].search(
+            [("partner_id", "=", self.partner_id.id)]
+        ) or self.env["res.company"].search(
+            [("partner_id", "=", self.partner_id.parent_id.id)]
+        )
+        if is_intercompany and self.company_id.sync_picking \
+                and self.picking_type_code == "outgoing":
+            sale_order = self.sale_id
+            src_pickings = sale_order.picking_ids.filtered(
+                lambda l: l.state in ['draft', 'waiting', 'confirmed', 'assigned']
+            )
+            dest_company = sale_order.partner_id.ref_company_ids
+            for src_picking in src_pickings:
+                src_picking._sync_receipt_with_delivery(
+                    dest_company,
+                    sale_order,
+                    src_pickings,
+                )
+        return super().button_validate()
+
+    @api.model
+    def _prepare_picking_line_data(self, src_picking, dest_picking):
+        self.ensure_one()
+        if self.check_all_done(src_picking):
+            for line in src_picking.sudo().move_ids_without_package:
+                line.write({
+                    'quantity_done': line.reserved_availability
+                })
+        for src_line in src_picking.sudo().move_ids_without_package:
+            if (
+                src_line.product_id
+                in dest_picking.sudo().move_ids_without_package.mapped("product_id")
+                and src_line.quantity_done > 0
+            ):
+                dest_move = dest_picking.sudo().move_ids_without_package.filtered(
+                    lambda m: m.product_id == src_line.product_id
+                )
+                dest_move.write({
+                    "quantity_done": dest_move.quantity_done + src_line.quantity_done
+                })
+
+    @api.multi
+    def _sync_receipt_with_delivery(self, dest_company, sale_order, src_pickings):
+        self.ensure_one()
+        intercompany_user = dest_company.intercompany_user_id
+        purchase_order = (
+            self.sudo(intercompany_user.id)
+            .env["purchase.order"]
+            .search(
+                [
+                    ("partner_ref", "=", sale_order.name),
+                    ("company_id", "=", dest_company.id),
+                ]
+            )
+        )
+        if (
+            not purchase_order
+            or not purchase_order.sudo(intercompany_user.id).picking_ids
+        ):
+            raise UserError(_("PO does not exist or has no receipts"))
+        receipts = purchase_order.sudo(intercompany_user.id).picking_ids
+        for src_picking in src_pickings.sudo().filtered(lambda l: l.state != "done"):
+            dest_picking = receipts.sudo().filtered(
+                lambda r: not r.intercompany_picking_id
+                or r.intercompany_picking_id.id == src_picking.id
+            )
+            if not dest_picking:
+                dest_picking = receipts.sudo().filtered(
+                    lambda r: r.state not in ['done', 'draft', 'cancel']
+                )
+            if (
+                dest_picking
+                and src_picking.state not in ["done", "cancel"]
+                and sum(src_picking.mapped(
+                    "move_ids_without_package.quantity_done"
+                )) > 0 or self.check_all_done(src_picking)
+            ):
+                dest_picking._prepare_picking_line_data(
+                    src_picking,
+                    dest_picking,
+                )
+                dest_picking.write(
+                    {
+                        "intercompany_picking_id": src_picking.id,
+                    }
+                )
+                src_picking.sudo().write(
+                    {
+                        "intercompany_picking_id": dest_picking.id,
+                    }
+                )
+                dest_picking.action_confirm()
+
+    def check_all_done(self, picking):
+        qty_done = sum(picking.mapped(
+            "move_ids_without_package.quantity_done"
+        ))
+        reserved = sum(picking.mapped(
+            "move_ids_without_package.reserved_availability"
+        ))
+        available = sum(picking.mapped(
+            "move_ids_without_package.product_uom_qty"
+        ))
+        if qty_done == 0.0 and reserved == available:
+            return True
+        return False
+
+    def action_generate_backorder_wizard(self):
+        view = self.env.ref('stock.view_backorder_confirmation')
+        wiz = self.env['stock.backorder.confirmation'].with_context(
+            picking_id=self.id
+        ).create({'pick_ids': [(4, p.id) for p in self]})
+        return {
+            'name': _('Create Backorder?'),
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'stock.backorder.confirmation',
+            'views': [(view.id, 'form')],
+            'view_id': view.id,
+            'target': 'new',
+            'res_id': wiz.id,
+            'context': self.env.context,
+        }

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -13,6 +13,9 @@
                 <field name="intercompany_overwrite_purchase_price" class="oe_inline"
                        domain="[('company_id', '=', company_id)]"/>
                 <label string="Intercompany Overwrite Purchase Price" class="o_light_label" for="intercompany_overwrite_purchase_price"/>
+                <field name="sync_picking" class="oe_inline"
+                       domain="[('company_id', '=', company_id)]"/>
+                <label string="Sync picking" class="o_light_label" for="sync_picking"/>
             </div>
             <div id="inter_company_warehouse"
                 attrs="{'invisible':['|', ('company_id', '=', False), ('so_from_po', '=', False)]}">

--- a/purchase_sale_inter_company/wizard/__init__.py
+++ b/purchase_sale_inter_company/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_backorder_confirmation

--- a/purchase_sale_inter_company/wizard/stock_backorder_confirmation.py
+++ b/purchase_sale_inter_company/wizard/stock_backorder_confirmation.py
@@ -1,0 +1,36 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockBackorderConfirmation(models.TransientModel):
+    _inherit = 'stock.backorder.confirmation'
+
+    force_backorder = fields.Boolean(string="Force backorder", default=False)
+    force_no_backorder = fields.Boolean(string="Force No backorder", default=False)
+
+    @api.model
+    def default_get(self, fields):
+        res = super(StockBackorderConfirmation, self).default_get(fields)
+        picking = self.env["stock.picking"].browse(
+            self.env.context.get("picking_id", False)
+        )
+        sale_order = self.env["sale.order"]
+        if picking.picking_type_code == "incoming":
+            sale_order = sale_order.search([(
+                'name', '=', picking.purchase_id.partner_ref
+            )])
+        if not picking or not sale_order:
+            return res
+        is_intercompany = self.env["res.company"].search(
+            [("partner_id", "=", picking.partner_id.id)]
+        ) or self.env["res.company"].search(
+            [("partner_id", "=", picking.partner_id.parent_id.id)]
+        )
+        if is_intercompany and is_intercompany.sync_picking \
+                and picking.picking_type_code == "incoming":
+            if sale_order.shipping_status == "completed":
+                res.update({"force_no_backorder": True})
+            else:
+                res.update({"force_backorder": True})
+        return res

--- a/purchase_sale_inter_company/wizard/stock_backorder_confirmation.py
+++ b/purchase_sale_inter_company/wizard/stock_backorder_confirmation.py
@@ -17,7 +17,7 @@ class StockBackorderConfirmation(models.TransientModel):
         )
         sale_order = self.env["sale.order"]
         if picking.picking_type_code == "incoming":
-            sale_order = sale_order.search([(
+            sale_order = sale_order.sudo().search([(
                 'name', '=', picking.purchase_id.partner_ref
             )])
         if not picking or not sale_order:

--- a/purchase_sale_inter_company/wizard/stock_backorder_confirmation_views.xml
+++ b/purchase_sale_inter_company/wizard/stock_backorder_confirmation_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_backorder_confirmation_inherit" model="ir.ui.view">
+        <field name="name">stock_backorder_confirmation_inherit</field>
+        <field name="model">stock.backorder.confirmation</field>
+        <field name="inherit_id" ref="stock.view_backorder_confirmation"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='process']" position="after">
+                <field name="force_backorder" invisible="1"/>
+                <field name="force_no_backorder" invisible="1"/>
+            </xpath>
+            <xpath expr="//button[@name='process_cancel_backorder']" position="attributes">
+                <attribute name="attrs">{'invisible': [('force_backorder', '=', True)]}</attribute>
+            </xpath>
+            <xpath expr="//button[@name='process']" position="attributes">
+                <attribute name="attrs">{'invisible': [('force_no_backorder', '=', True)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a field in the settings to sync the deliveries from the sale order with the receipts from the purchase order when activated for intercompany operations.

@JoanSForgeFlow @LoisRForgeFlow 