### PR TITLE
[FIX] [product_supplierinfo_intercompany] same company as buyer and seller

### DIFF
--- a/product_supplierinfo_intercompany/models/product_product.py
+++ b/product_supplierinfo_intercompany/models/product_product.py
@@ -25,6 +25,19 @@ class ProductProduct(models.Model):
         )
         return vals
 
+    def _prepare_sellers(self, params):
+        sellers = super()._prepare_sellers(params)
+        sellers = sellers.filtered_domain(
+            [
+                "|",
+                ("intercompany_pricelist_id", "=", False),
+                "&",
+                ("intercompany_pricelist_id", "!=", False),
+                ("intercompany_pricelist_id.company_id", "!=", self.env.company),
+            ]
+        )
+        return sellers
+
     def _has_intercompany_price(self, pricelist):
         self.ensure_one()
         if (


### PR DESCRIPTION
If a buyer company is also a seller in another company for the same product, this company can be selected as seller for itself. 
This PR fixe it. 