### PR TITLE
[14.0][ADD] sale_partner_company_check

### DIFF
--- a/sale_partner_company_check/__init__.py
+++ b/sale_partner_company_check/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_partner_company_check/__manifest__.py
+++ b/sale_partner_company_check/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Partner Company Check",
+    "summary": """Check company's partner
+            before to set him a specific company""",
+    "version": "14.0.1.0.0",
+    "category": "Tools",
+    "website": "https://github.com/OCA/multi-company",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "sale",
+        "base_company_check",
+    ],
+}

--- a/sale_partner_company_check/models/__init__.py
+++ b/sale_partner_company_check/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/sale_partner_company_check/models/res_partner.py
+++ b/sale_partner_company_check/models/res_partner.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = ["res.partner", "company.check.mixin"]
+    _name = "res.partner"
+
+    def _allowed_company_get_fields_to_check(self):
+        return ["sale_order_ids", "invoice_ids"]

--- a/sale_partner_company_check/readme/CONTRIBUTORS.rst
+++ b/sale_partner_company_check/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kévin Roche <kevin.roche@akretion.com>

--- a/sale_partner_company_check/readme/DESCRIPTION.rst
+++ b/sale_partner_company_check/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module checks company of related partner's invoices and sales before assigning a new company to this partner. If a sale or invoice of a partner is in a company, we don't allow to assign another company to this partner.

--- a/sale_partner_company_check/tests/__init__.py
+++ b/sale_partner_company_check/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_partner_company_check

--- a/sale_partner_company_check/tests/test_sale_partner_company_check.py
+++ b/sale_partner_company_check/tests/test_sale_partner_company_check.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import SavepointCase
+
+
+class TestSalePartnerCompanyCheck(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestSalePartnerCompanyCheck, cls).setUpClass()
+
+        cls.company_1 = cls.env["res.company"].create({"name": "company 1"})
+        cls.company_2 = cls.env["res.company"].create({"name": "company 2"})
+        # partner with company_id = company_1
+        cls.partner = cls.env.ref("base.res_partner_address_10")
+
+    def test_1_no_existing_sale_in_company(self):
+        self.partner.company_id = self.company_1
+        self.partner.company_id = self.company_2
+
+    def test_2_existing_sale_in_company(self):
+        self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+            }
+        )
+        with self.assertRaises(UserError) as m:
+            self.partner.write({"company_id": self.company_2.id})
+        self.assertEqual(
+            m.exception.name,
+            "It's not possible to set the company company 2 to the "
+            "record Jesse Brown as it have been used by company 1",
+        )

--- a/setup/sale_partner_company_check/odoo/addons/sale_partner_company_check
+++ b/setup/sale_partner_company_check/odoo/addons/sale_partner_company_check
@@ -1,0 +1,1 @@
+../../../../sale_partner_company_check

--- a/setup/sale_partner_company_check/setup.py
+++ b/setup/sale_partner_company_check/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module checks company of related partner's invoices and sales before assigning a new company to this partner. If a sale or invoice of a partner is in a company, we don't allow to assign another company to this partner.

depends on https://github.com/OCA/multi-company/pull/396

cc @sebastienbeau 