### PR TITLE
[14.0][ADD] invoice_product_company_check

### DIFF
--- a/invoice_product_company_check/__init__.py
+++ b/invoice_product_company_check/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/invoice_product_company_check/__manifest__.py
+++ b/invoice_product_company_check/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Invoice Product Company Check",
+    "summary": """Check company's product
+            before to set him a specific company""",
+    "version": "14.0.1.0.0",
+    "category": "Tools",
+    "website": "https://github.com/OCA/multi-company",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "sale",
+        "base_company_check",
+    ],
+}

--- a/invoice_product_company_check/models/__init__.py
+++ b/invoice_product_company_check/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_product

--- a/invoice_product_company_check/models/product_product.py
+++ b/invoice_product_company_check/models/product_product.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _name = "product.product"
+    _inherit = ["product.product", "company.check.mixin"]
+
+    invoice_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        compute="_compute_invoice_line_ids",
+        string="Invoice Line",
+    )
+
+    def _compute_invoice_line_ids(self):
+        for rec in self:
+            lines = self.env["account.move.line"].search([("product_id", "=", rec.id)])
+            rec.invoice_line_ids = [(6, 0, lines.ids)]
+
+    # Sale order_line are already check in odoo sale.
+    def _allowed_company_get_fields_to_check(self):
+        return ["invoice_line_ids"]

--- a/invoice_product_company_check/readme/CONTRIBUTORS.rst
+++ b/invoice_product_company_check/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kévin Roche <kevin.roche@akretion.com>

--- a/invoice_product_company_check/readme/DESCRIPTION.rst
+++ b/invoice_product_company_check/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module checks company of invoices with a specific product, before assigning a new company to this product. If an invoice with a product is in a company, we don't allow to assign another company to this product.

--- a/invoice_product_company_check/tests/__init__.py
+++ b/invoice_product_company_check/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_product_company_check

--- a/invoice_product_company_check/tests/test_sale_product_company_check.py
+++ b/invoice_product_company_check/tests/test_sale_product_company_check.py
@@ -1,0 +1,47 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import SavepointCase
+
+
+class TestSaleProductCompanyCheck(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaleProductCompanyCheck, cls).setUpClass()
+
+        cls.company_1 = cls.env["res.company"].create({"name": "company 1"})
+        cls.company_2 = cls.env["res.company"].create({"name": "company 2"})
+        # partner with company_id = company_1
+        cls.partner = cls.env.ref("base.res_partner_address_10")
+        cls.product = cls.env["product.product"].create({"name": "Product"})
+
+    def test_1_no_existing_sale_in_company(self):
+        self.product.company_id = self.company_1
+        self.product.company_id = self.company_2
+
+    def test_2_existing_sale_in_company(self):
+        self.env["account.move"].create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "out_invoice",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "First",
+                            "product_id": self.product.id,
+                        },
+                    )
+                ],
+            }
+        )
+        with self.assertRaises(UserError) as m:
+            self.product.write({"company_id": self.company_2.id})
+        self.assertEqual(
+            m.exception.args[0],
+            "It's not possible to set the company company 2 to the "
+            "record Product as it have been used by company 1",
+        )

--- a/setup/invoice_product_company_check/odoo/addons/invoice_product_company_check
+++ b/setup/invoice_product_company_check/odoo/addons/invoice_product_company_check
@@ -1,0 +1,1 @@
+../../../../invoice_product_company_check

--- a/setup/invoice_product_company_check/setup.py
+++ b/setup/invoice_product_company_check/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module checks company of related invoices including a product before assigning a new company to this product. If a product in an invoice is in a company, we don't allow to assign another company to this product.

depends on https://github.com/OCA/multi-company/pull/396

cc @sebastienbeau