### PR TITLE
product_supplierinfo_group_intercompany: fix broken update of supplierinfo

### DIFF
--- a/product_supplierinfo_group_intercompany/__manifest__.py
+++ b/product_supplierinfo_group_intercompany/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Product Supplierinfo Group Intercompany Sequence",
     "summary": """
         Add sequence field on grouped pricelist items""",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.1.0",
     "license": "AGPL-3",
     "author": "Akretion,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/multi-company",

--- a/product_supplierinfo_group_intercompany/migrations/14.0.1.1.0/post-fix-data.py
+++ b/product_supplierinfo_group_intercompany/migrations/14.0.1.1.0/post-fix-data.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {"automatic_intercompany_sync": True})
+    suppliers = env["product.supplierinfo"].search(
+        [
+            ("group_id.intercompany_pricelist_id", "!=", False),
+            ("intercompany_pricelist_id", "=", False),
+        ]
+    )
+    for supplier in suppliers:
+        variant = supplier.product_id
+        template = supplier.product_tmpl_id
+        pricelist = supplier.group_id.intercompany_pricelist_id
+        supplier.unlink()
+        if variant:
+            variant._synchronise_supplier_info(pricelist)
+        else:
+            template._synchronise_supplier_info(pricelist)

--- a/product_supplierinfo_group_intercompany/models/product_supplierinfo.py
+++ b/product_supplierinfo_group_intercompany/models/product_supplierinfo.py
@@ -2,13 +2,18 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
-from odoo import models
+from odoo import fields, models
 
 
 class ProductSupplierinfo(models.Model):
     _inherit = "product.supplierinfo"
     # we add the 'product_id' in the order see comment in product_supplierinfo_group.py
     _order = "sequence, product_id, min_qty DESC, price, id"
+
+    intercompany_pricelist_id = fields.Many2one(
+        related="group_id.intercompany_pricelist_id",
+        store=True,
+    )
 
     def unlink(self):
         groups = self.group_id.filtered(lambda r: r.intercompany_pricelist_id)

--- a/product_supplierinfo_group_intercompany/tests/test_product_supplerinfo_group.py
+++ b/product_supplierinfo_group_intercompany/tests/test_product_supplerinfo_group.py
@@ -64,3 +64,10 @@ class IntercompanySupplierinfoGroupTest(
         )
         user.company_ids = self.sale_company
         self.assertFalse(self.product_template_4.with_user(user).supplierinfo_group_ids)
+
+    def test_add_and_update_product_item(self):
+        product = self.env.ref("product.product_product_3")
+        item = self._add_item(product, 22)
+        self._check_supplier_info_for(product, 22)
+        item.fixed_price = 30
+        self._check_supplier_info_for(product, 30)

--- a/product_supplierinfo_intercompany/models/product_supplierinfo.py
+++ b/product_supplierinfo_intercompany/models/product_supplierinfo.py
@@ -30,8 +30,6 @@ class ProductSupplierinfo(models.Model):
         comodel_name="product.pricelist",
     )
 
-    pricelist_item_id = fields.Many2one(comodel_name="product.pricelist.item")
-
     def check_access_rule(self, operation):
         super().check_access_rule(operation)
         if operation in ("write", "create", "unlink"):


### PR DESCRIPTION
A related field was missing, so everytime you update a pricelist item a new supplierinfo was created instead of updating the existing one.

A migration script is included to clean the duplicated data
Also test have been added