### PR TITLE
[FIX] creation of company-bound category with parent that is bound to …

### DIFF
--- a/product_category_inter_company/models/product_category.py
+++ b/product_category_inter_company/models/product_category.py
@@ -22,7 +22,7 @@ class ProductCategory(models.Model):
         for record in self:
             if (
                 record.parent_id.company_id
-                and not record.parent_id.company_id != record.company_id
+                and record.parent_id.company_id != record.company_id
             ):
                 raise UserError(
                     _(


### PR DESCRIPTION
…the same company

The condition is obviously wrong (double negated) meaning: if the parent  has company and own company and parent company are equal, throw an error...

A test would be fine but I don't currently have time for that...