### PR TITLE
[14.0][FIX] account_invoice_inter_company : run tests at post install

### DIFF
--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -5,9 +5,11 @@
 
 from odoo import _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
 from odoo.tests.common import Form, SavepointCase
 
 
+@tagged("post_install", "-at_install")
 class TestAccountInvoiceInterCompanyBase(SavepointCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Describe the bug
When creating a brand new database with demo data and installing **account_invoice_inter_company** module, an error occurred during tests setup telling:
```
odoo.exceptions.ValidationError: No Chart of Account Template has been defined !
```

This is due to **l10n_generic_coa** not already installed.
The actual installation takes place at the end of initialization, due to **post_init_hook** of **account** module calling "**_account_post_init**" which calls "**_auto_install_l10n**"

Can't we run those tests with **post_install** tag ?

## To Reproduce
**14.0**:

Steps to reproduce the behavior:
- Just run `odoo-bin -i account_invoice_inter_company -d 14_ce_test_invoice_inter_company_02 --test-enable --stop-after-init`

**Current behaviour**
```
2022-12-07 11:23:55,839 1 INFO 14_ce_test_invoice_inter_company_02 odoo.modules.loading: Module account_invoice_inter_company: loading demo 
2022-12-07 11:23:55,851 1 INFO 14_ce_test_invoice_inter_company_02 unittest.suite: ====================================================================== 
2022-12-07 11:23:55,851 1 ERROR 14_ce_test_invoice_inter_company_02 unittest.suite: ERROR: setUpClass (odoo.addons.account_invoice_inter_company.tests.test_inter_company_invoice.TestAccountInvoiceInterCompany)
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/tests/common.py", line 173, in _handleClassSetUp
    setUpClass()
  File "/mnt/extra-addons/multi-company/account_invoice_inter_company/tests/test_inter_company_invoice.py", line 21, in setUpClass
    _("No Chart of Account Template has been defined !")
odoo.exceptions.ValidationError: No Chart of Account Template has been defined !
 
2022-12-07 11:23:55,997 1 INFO 14_ce_test_invoice_inter_company_02 odoo.modules.loading: Module account_invoice_inter_company loaded in 0.83s (incl. 0.08s test), 282 queries (+3 test) 
2022-12-07 11:23:55,997 1 ERROR 14_ce_test_invoice_inter_company_02 odoo.modules.loading: Module account_invoice_inter_company: 0 failures, 1 errors of 0 tests
```

**Expected behavior**
No error when running tests...

**Additional context**
This also happens in 13.0

I also wonder why this isn't visible on Travis checks.