### PR TITLE
[13.0][FIX] account_invoice_inter_company : run test at post install

### DIFF
--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -5,9 +5,11 @@
 
 from odoo import _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
 from odoo.tests.common import Form, SavepointCase
 
 
+@tagged("post_install", "-at_install")
 class TestAccountInvoiceInterCompanyBase(SavepointCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This avoids getting a "No Chart of Account Template has been defined !" error on fresh database install

Backported from 14.0