### PR TITLE
[13.0] account_invoice_inter_company : actually postpone tests after install

### DIFF
--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -414,6 +414,7 @@ class TestAccountInvoiceInterCompanyBase(SavepointCase):
         ).property_account_expense_id = cls.a_expense_company_b.id
 
 
+@tagged("post_install", "-at_install")
 class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
     def test01_user(self):
         # Check user of company B (company of destination)


### PR DESCRIPTION
This is a follow-up of the PR #419, it seems in 13.0, subclasses should also be tagged