### PR TITLE
[15.0][FIX] base_multi_company: move test dependency to test-requirements

### DIFF
--- a/base_multi_company/__manifest__.py
+++ b/base_multi_company/__manifest__.py
@@ -13,5 +13,4 @@
     "application": False,
     "development_status": "Production/Stable",
     "maintainers": ["pedrobaeza"],
-    "external_dependencies": {"python": ["odoo-test-helper"]},
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 # generated from manifests external_dependencies
-odoo-test-helper

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-test-helper


### PR DESCRIPTION
remove external dependency. it is only needed for tests.