### PR TITLE
[FIX] account_invoice_inter_company: update products purchase_line_warn

### DIFF
--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -335,6 +335,11 @@ class TestAccountInvoiceInterCompanyBase(TransactionCase):
             # We have to do that because the default method added a company
             cls.product_consultant_multi_company.company_ids = False
 
+        # if purchase_sale_stock_inter_company is installed
+        if "purchase_line_warn" in cls.env["product.template"]._fields:
+            # null value in column "purchase_line_warn" violates not-null constraint is raised
+            cls.env["product.template"].search([]).purchase_line_warn = "no-message"
+
         cls.env["ir.sequence"].create(
             {
                 "name": "Account Sales Journal Company A",


### PR DESCRIPTION
If `purchase_sale_stock_inter_company` is installed we have
`psycopg2.errors.NotNullViolation: null value in column "purchase_line_warn" violates not-null constraint`
though `purchase_line_warn` has a default value.