### PR TITLE
[FIX] account_move_change_company: Journal id needs to be recomputed

### DIFF
--- a/account_move_change_company/models/account_move.py
+++ b/account_move_change_company/models/account_move.py
@@ -40,7 +40,8 @@ class AccountMove(models.Model):
         if not self.is_invoice():
             self.line_ids = [(5, 0, 0)]
             return
-        # Forcing recalculation of change of partner
+        # Forcing recalculation of change of partner and journal
+        self._onchange_journal()
         self._onchange_partner_id()
         for line in self.invoice_line_ids:
             line.account_id = line._get_computed_account()


### PR DESCRIPTION
It is necessary due to the change of the sequence calculation.