### PR TITLE
[14.0][FIX] account_multicompany_easy_creation: Only one default exists

### DIFF
--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
@@ -154,8 +154,7 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
                     {
                         "code": False,
                         "sequence_id": False,
-                        "default_debit_account_id": account_account.id,
-                        "default_credit_account_id": account_account.id,
+                        "default_account_id": account_account.id,
                     }
                 )
                 AccountJournal.create(vals)


### PR DESCRIPTION
On a random review I found this small bug :smile: 