### PR TITLE
[BKP][14.0] product_tax_multicompany_default: Overwrite taxes instead of adding it

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.12.0
+_commit: v1.14.2
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
 github_check_license: true
+github_ci_extra_env: {}
 github_enable_codecov: true
 github_enable_makepot: true
 github_enable_stale_action: true
@@ -13,7 +14,8 @@ include_wkhtmltopdf: false
 odoo_version: 14.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- product_tax_multicompany_default
 repo_description: Addons for the management of multi company instances as well as
 repo_name: Multi company modules
 repo_slug: multi-company

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:
@@ -36,9 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            include: "product_tax_multicompany_default"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            include: "product_tax_multicompany_default"
+            name: test with OCB
+          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            exclude: "product_tax_multicompany_default"
+            makepot: "true"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            exclude: "product_tax_multicompany_default"
             name: test with OCB
     services:
       postgres:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.5.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/product_tax_multicompany_default/__manifest__.py
+++ b/product_tax_multicompany_default/__manifest__.py
@@ -11,4 +11,5 @@
     "license": "AGPL-3",
     "depends": ["account", "product"],
     "data": ["views/product_template_view.xml"],
+    "maintainers": ["Shide"],
 }

--- a/product_tax_multicompany_default/models/product.py
+++ b/product_tax_multicompany_default/models/product.py
@@ -1,6 +1,9 @@
 # Copyright 2017 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # Copyright 2018 Vicent Cubells - Tecnativa <vicent.cubells@tecnativa.com>
+# Copyright 2023 Eduardo de Miguel - Moduon <edu@moduon.team>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from typing import List
 
 from odoo import api, models
 
@@ -24,6 +27,32 @@ class ProductTemplate(models.Model):
             )
         return taxes_ids
 
+    def _delete_product_taxes(
+        self,
+        excl_customer_tax_ids: List[int] = None,
+        excl_supplier_tax_ids: List[int] = None,
+    ):
+        """Delete taxes from product excluding chosen taxes
+
+        :param excl_customer_tax_ids: Excluded customer tax ids
+        :param excl_supplier_tax_ids: Excluded supplier tax ids
+        """
+        tax_where = " AND tax_id NOT IN %s"
+        # Delete customer taxes
+        customer_sql = "DELETE FROM product_taxes_rel WHERE prod_id IN %s"
+        customer_sql_params = [tuple(self.ids)]
+        if excl_customer_tax_ids:
+            customer_sql += tax_where
+            customer_sql_params.append(tuple(excl_customer_tax_ids))
+        self.env.cr.execute(customer_sql + ";", customer_sql_params)
+        # Delete supplier taxes
+        supplier_sql = "DELETE FROM product_supplier_taxes_rel WHERE prod_id IN %s"
+        supplier_sql_params = [tuple(self.ids)]
+        if excl_supplier_tax_ids:
+            supplier_sql += tax_where
+            supplier_sql_params.append(tuple(excl_supplier_tax_ids))
+        self.env.cr.execute(supplier_sql + ";", supplier_sql_params)
+
     def set_multicompany_taxes(self):
         self.ensure_one()
         user_company = self.env.company
@@ -41,6 +70,11 @@ class ProductTemplate(models.Model):
         )
         default_supplier_tax_ids = obj.taxes_by_company(
             "account_purchase_tax_id", user_company
+        )
+        # Clean taxes from other companies (cannot replace it with sudo)
+        self._delete_product_taxes(
+            excl_customer_tax_ids=customer_tax_ids,
+            excl_supplier_tax_ids=supplier_tax_ids,
         )
         # Use list() to copy list
         match_customer_tax_ids = (

--- a/product_tax_multicompany_default/readme/CONTRIBUTORS.rst
+++ b/product_tax_multicompany_default/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
   * Pedro M. Baeza
   * Vicent Cubells
   * Ernesto Tejeda
+
+* `Moduon <https://www.moduon.team>`_:
+
+  * Eduardo de Miguel

--- a/product_tax_multicompany_default/readme/USAGE.rst
+++ b/product_tax_multicompany_default/readme/USAGE.rst
@@ -1,3 +1,4 @@
+#. User must have group Full Accounting Features (account.group_account_user)
 #. Go to Invoicing > Customers > Products.
 #. Create a new product and save it.
 #. Switching user company you will see that the product has the default taxes

--- a/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
+++ b/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
@@ -1,7 +1,9 @@
 # Copyright 2017 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # Copyright 2018 Vicent Cubells - Tecnativa <vicent.cubells@tecnativa.com>
+# Copyright 2023 Eduardo de Miguel - Moduon Team <edu@moduon.team>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.tests import Form
 from odoo.tests.common import SavepointCase
 
 
@@ -12,12 +14,14 @@ class TestsProductTaxMulticompany(SavepointCase):
         cls.company_1 = cls.env["res.company"].create({"name": "Test company 1"})
         cls.company_2 = cls.env["res.company"].create({"name": "Test company 2"})
         group_account_manager = cls.env.ref("account.group_account_manager")
+        group_account_user = cls.env.ref("account.group_account_user")
+        group_multi_company = cls.env.ref("base.group_multi_company")
         ResUsers = cls.env["res.users"]
         cls.user_1 = ResUsers.create(
             {
-                "name": "User not admin",
+                "name": "User not admin 1",
                 "login": "user_1",
-                "email": "test@test.com",
+                "email": "test1@test.com",
                 "groups_id": [(6, 0, group_account_manager.ids)],
                 "company_id": cls.company_1.id,
                 "company_ids": [(6, 0, cls.company_1.ids)],
@@ -25,12 +29,32 @@ class TestsProductTaxMulticompany(SavepointCase):
         )
         cls.user_2 = ResUsers.create(
             {
-                "name": "User not admin",
+                "name": "User not admin 2",
                 "login": "user_2",
-                "email": "test@test.com",
+                "email": "test2@test.com",
                 "groups_id": [(6, 0, group_account_manager.ids)],
                 "company_id": cls.company_2.id,
                 "company_ids": [(6, 0, cls.company_2.ids)],
+            }
+        )
+        cls.user_3 = ResUsers.create(
+            {
+                "name": "User not admin 3",
+                "login": "user_3",
+                "email": "test3@test.com",
+                "groups_id": [
+                    (
+                        6,
+                        0,
+                        (
+                            group_account_manager
+                            | group_account_user
+                            | group_multi_company
+                        ).ids,
+                    )
+                ],
+                "company_id": cls.company_1.id,
+                "company_ids": [(6, 0, (cls.company_1 | cls.company_2).ids)],
             }
         )
         AccountTax = cls.env["account.tax"]
@@ -45,6 +69,12 @@ class TestsProductTaxMulticompany(SavepointCase):
         tax_vals.update({"name": "Test Customer Tax 20%", "amount": 20.0})
         cls.tax_20_cc1 = AccountTax.with_user(cls.user_1.id).create(tax_vals)
         cls.tax_20_cc2 = AccountTax.with_user(cls.user_2.id).create(tax_vals)
+        tax_vals.update({"name": "Test Customer Tax 30%", "amount": 30.0})
+        cls.tax_30_cc1 = AccountTax.with_user(cls.user_1.id).create(tax_vals)
+        cls.tax_30_cc2 = AccountTax.with_user(cls.user_2.id).create(tax_vals)
+        tax_vals.update({"name": "Test Customer Tax 40%", "amount": 40.0})
+        cls.tax_40_cc1 = AccountTax.with_user(cls.user_1.id).create(tax_vals)
+        cls.tax_40_cc2 = AccountTax.with_user(cls.user_2.id).create(tax_vals)
         tax_vals.update(
             {
                 "name": "Test Supplier Tax 10%",
@@ -57,6 +87,12 @@ class TestsProductTaxMulticompany(SavepointCase):
         tax_vals.update({"name": "Test Supplier Tax 20%", "amount": 20.0})
         cls.tax_20_sc1 = AccountTax.with_user(cls.user_1.id).create(tax_vals)
         cls.tax_20_sc2 = AccountTax.with_user(cls.user_2.id).create(tax_vals)
+        tax_vals.update({"name": "Test Supplier Tax 30%", "amount": 30.0})
+        cls.tax_30_sc1 = AccountTax.with_user(cls.user_1.id).create(tax_vals)
+        cls.tax_30_sc2 = AccountTax.with_user(cls.user_2.id).create(tax_vals)
+        tax_vals.update({"name": "Test Supplier Tax 40%", "amount": 40.0})
+        cls.tax_40_sc1 = AccountTax.with_user(cls.user_1.id).create(tax_vals)
+        cls.tax_40_sc2 = AccountTax.with_user(cls.user_2.id).create(tax_vals)
         cls.company_1.account_sale_tax_id = cls.tax_10_cc1.id
         cls.company_1.account_purchase_tax_id = cls.tax_10_sc1.id
         cls.company_2.account_sale_tax_id = cls.tax_20_cc2.id
@@ -126,3 +162,75 @@ class TestsProductTaxMulticompany(SavepointCase):
         product = product.sudo()
         self.assertIn(self.tax_10_cc2, product.taxes_id)
         self.assertIn(self.tax_10_sc2, product.supplier_taxes_id)
+
+    def test_set_multicompany_taxes(self):
+        # Create product with empty taxes
+        pf_u3_c1 = Form(
+            self.env["product.product"]
+            .with_user(self.user_3.id)
+            .with_company(self.company_1)
+        )
+        pf_u3_c1.name = "Testing Empty Taxes"
+        pf_u3_c1.taxes_id.clear()
+        pf_u3_c1.supplier_taxes_id.clear()
+        product = pf_u3_c1.save()
+        self.assertFalse(
+            product.sudo().taxes_id,
+            "Taxes not empty when initializing product",
+        )
+        pf_u3_c1 = Form(product.with_user(self.user_3.id).with_company(self.company_1))
+        # Fill taxes
+        pf_u3_c1.name = "Testing Filling Taxes"
+        pf_u3_c1.taxes_id.add(self.tax_30_cc1)
+        pf_u3_c1.supplier_taxes_id.add(self.tax_30_sc1)
+        product = pf_u3_c1.save()
+        self.assertEqual(
+            product.sudo().taxes_id,
+            self.tax_30_cc1,
+            "Taxes has been propagated before calling set_multicompany_taxes",
+        )
+        product.with_user(self.user_3.id).with_company(
+            self.company_1
+        ).set_multicompany_taxes()
+        company_1_taxes_fill = product.sudo().taxes_id.filtered(
+            lambda t: t.company_id == self.company_1
+        )
+        company_2_taxes_fill = product.sudo().taxes_id.filtered(
+            lambda t: t.company_id == self.company_2
+        )
+        self.assertEqual(
+            company_1_taxes_fill,
+            self.tax_30_cc1,
+            "Incorrect taxes when setting it for the first time in Company 1",
+        )
+        self.assertEqual(
+            company_2_taxes_fill,
+            self.tax_30_cc2,
+            "Incorrect taxes when setting it for the first time in Company 2",
+        )
+        # Change taxes
+        pf_u3_c1.name = "Testing Change Taxes"
+        pf_u3_c1.taxes_id.clear()
+        pf_u3_c1.taxes_id.add(self.tax_40_cc1)
+        pf_u3_c1.supplier_taxes_id.clear()
+        pf_u3_c1.supplier_taxes_id.add(self.tax_40_sc1)
+        product = pf_u3_c1.save()
+        product.with_user(self.user_3.id).with_company(
+            self.company_1
+        ).set_multicompany_taxes()
+        company_1_taxes_change = product.sudo().taxes_id.filtered(
+            lambda t: t.company_id == self.company_1
+        )
+        company_2_taxes_change = product.sudo().taxes_id.filtered(
+            lambda t: t.company_id == self.company_2
+        )
+        self.assertEqual(
+            company_1_taxes_change,
+            self.tax_40_cc1,
+            "Incorrect taxes when changing it in Company 1",
+        )
+        self.assertEqual(
+            company_2_taxes_change,
+            self.tax_40_cc2,
+            "Incorrect taxes when changing it in Company 2",
+        )


### PR DESCRIPTION
Backporting Commit https://github.com/OCA/multi-company/commit/afb5733aa2a165355880b4923125709453cb802c done in v16 migration.

Same backport as https://github.com/OCA/multi-company/pull/447 PR

MT-2121 @moduon @rafaelbn @carlosdauden