### PR TITLE
[14.0][FIX] `partner_multi_company` removes partner_share from res.partner ir.rule

### DIFF
--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -36,9 +36,8 @@ def uninstall_hook(cr, registry):
             {
                 "active": False,
                 "domain_force": (
-                    "['|','|',('company_id.child_ids','child_of',"
-                    "[user.company_id.id]),('company_id','child_of',"
-                    "[user.company_id.id]),('company_id','=',False)]"
+                    "['|', '|', ('partner_share', '=', False), ('company_id', 'in', company_ids), "
+                    "('company_id', '=', False)]"
                 ),
             }
         )

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -18,7 +18,7 @@ def post_init_hook(cr, registry):
                     "['|', '|',"
                     "('partner_share', '=', False),"
                     "('no_company_ids', '=', True),"
-                    "('company_ids', 'in', company_ids)]"
+                    "('company_ids', 'in', user.company_ids.ids)]"
                 ),
             }
         )

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -15,8 +15,10 @@ def post_init_hook(cr, registry):
             {
                 "active": True,
                 "domain_force": (
-                    "['|', '|', ('partner_share', '=', False), ('no_company_ids', '=', True),"
-                    " ('company_ids', 'in', company_ids)]"
+                    "['|', '|',"
+                    "('partner_share', '=', False),"
+                    "('no_company_ids', '=', True),"
+                    "('company_ids', 'in', company_ids)]"
                 ),
             }
         )

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -9,8 +9,6 @@ def post_init_hook(cr, registry):
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})
         rule = env.ref("base.res_partner_rule")
-        if not rule:  # safeguard if it's deleted
-            return
         rule.write(
             {
                 "active": True,

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -6,18 +6,20 @@ _logger = logging.getLogger(__name__)
 
 
 def post_init_hook(cr, registry):
-    rule = env.ref("base.res_partner_rule")
-    if not rule:  # safeguard if it's deleted
-        return
-    rule.write(
-        {
-            "active": True,
-            "domain_force": (
-                "['|', '|', ('partner_share', '=', False), ('no_company_ids', '=', True), ('company_ids', "
-                "'in', company_ids)]"
-            ),
-        }
-    )
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        rule = env.ref("base.res_partner_rule")
+        if not rule:  # safeguard if it's deleted
+            return
+        rule.write(
+            {
+                "active": True,
+                "domain_force": (
+                    "['|', '|', ('partner_share', '=', False), ('no_company_ids', '=', True),"
+                    " ('company_ids', 'in', company_ids)]"
+                ),
+            }
+        )
 
 
 def uninstall_hook(cr, registry):
@@ -36,7 +38,8 @@ def uninstall_hook(cr, registry):
             {
                 "active": False,
                 "domain_force": (
-                    "['|', '|', ('partner_share', '=', False), ('company_id', 'in', company_ids), "
+                    "['|', '|', ('partner_share', '=', False), "
+                    "('company_id', 'in', company_ids), "
                     "('company_id', '=', False)]"
                 ),
             }

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -4,17 +4,19 @@ from odoo import SUPERUSER_ID, api
 
 _logger = logging.getLogger(__name__)
 
-try:
-    from odoo.addons.base_multi_company import hooks
-except ImportError:
-    _logger.info("Cannot find `base_multi_company` module in addons path.")
-
 
 def post_init_hook(cr, registry):
-    hooks.post_init_hook(
-        cr,
-        "base.res_partner_rule",
-        "res.partner",
+    rule = env.ref("base.res_partner_rule")
+    if not rule:  # safeguard if it's deleted
+        return
+    rule.write(
+        {
+            "active": True,
+            "domain_force": (
+                "['|', '|', ('partner_share', '=', False), ('no_company_ids', '=', True), ('company_ids', "
+                "'in', company_ids)]"
+            ),
+        }
     )
 
 

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -128,10 +128,10 @@ class TestPartnerMultiCompany(common.TransactionCase):
         uninstall_hook(self.env.cr, None)
         rule = self.env.ref("base.res_partner_rule")
         domain = (
-            "['|','|',"
-            "('company_id.child_ids','child_of',[user.company_id.id]),"
-            "('company_id','child_of',[user.company_id.id]),"
-            "('company_id','=',False)]"
+            "['|', '|',"
+            "('partner_share', '=', False),"
+            "('no_company_ids', '=', True),"
+            "('company_ids', 'in', company_ids)]"
         )
         self.assertEqual(rule.domain_force, domain)
         self.assertFalse(rule.active)

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -131,7 +131,7 @@ class TestPartnerMultiCompany(common.TransactionCase):
             "['|', '|',"
             "('partner_share', '=', False),"
             "('no_company_ids', '=', True),"
-            "('company_ids', 'in', company_ids)]"
+            "('company_ids', 'in', user.company_ids.ids)]"
         )
         self.assertEqual(rule.domain_force, domain)
         self.assertFalse(rule.active)

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -128,10 +128,9 @@ class TestPartnerMultiCompany(common.TransactionCase):
         uninstall_hook(self.env.cr, None)
         rule = self.env.ref("base.res_partner_rule")
         domain = (
-            "['|', '|',"
-            "('partner_share', '=', False),"
-            "('no_company_ids', '=', True),"
-            "('company_ids', 'in', user.company_ids.ids)]"
+            "['|', '|', ('partner_share', '=', False), "
+            "('company_id', 'in', company_ids), "
+            "('company_id', '=', False)]"
         )
         self.assertEqual(rule.domain_force, domain)
         self.assertFalse(rule.active)


### PR DESCRIPTION
## Module `base_multi_company` and `partner_multi_company`
The bug is caused by the hook on `base_multi_company` and called by installing  `partner_multi_company`.
 
Odoo uses `partner_share` to share all the partner of internal users, so it can use them when there are relations to records. The hook of `base_multi_company` remove it from `base.res_partner_rule`

### `base.res_partner_rule` domain before and after installing `partner_multi_company`:
After: `['|', '|', ('partner_share', '=', False), ('company_id', 'in', company_ids), ('company_id', '=', False)] `
Before: `['|', ('no_company_ids', '=', True), ('company_ids', 'in', company_ids)]`

## Describe the bug
When a user A interacts with a record that is has interaction from another user B using `mail.activity` or another relation to the user, it causes an access error to the information of the partner related user if User A doesn't have access to User B company.

## To Reproduce
Tested on **14.0**

Steps to reproduce the behavior:
1. Create user A with only access to company A
2. Create user B with only access to company B
3. Create a record (res.partner for example) and give access to both companies (A and B)
4. User A creates a message or mail.activity on shared record.
5. User B when accessing shared record has an access error. (Can go inside the record but will not load the User A relations)

**Expected behavior**
When User B enters, the shared record should load without access error.

**Proposed solution**
Modify the `post_init_hook` and `unisstall_hook` of `partner_multi_company` to contemplate the `partner_share` field in the domain.


Add `partner_share` in domain of `post_init` and `unistall` hook of `partner_multi_company` 