### PR TITLE
[IMP] product_tax_multicompany_default: beautier and mass propagation

### DIFF
--- a/product_tax_multicompany_default/readme/USAGE.rst
+++ b/product_tax_multicompany_default/readme/USAGE.rst
@@ -1,9 +1,20 @@
+To propagate taxes in one product:
+
 #. User must have group Full Accounting Features (account.group_account_user)
 #. Go to Invoicing > Customers > Products.
 #. Create a new product and save it.
 #. Switching user company you will see that the product has the default taxes
    for all the companies.
 #. Change tax in a existing product
+#. If Odoo detects divergent taxes across companies, you will see a "Propagate Taxes" button.
 #. Click "Propagate Taxes" button
 #. Switching user company you will see that the product has the same taxes
    for all the companies.
+
+To propagate taxes in mass:
+
+#. User must have group Full Accounting Features (account.group_account_user)
+#. Open products list view.
+#. *Filters > Add custom filter > Has divergent cross-company taxes > is true > Apply*.
+#. Select all products that you want to change.
+#. *Action > Propagate Taxes*.

--- a/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
+++ b/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
@@ -13,6 +13,9 @@ class TestsProductTaxMulticompany(SavepointCase):
         super(TestsProductTaxMulticompany, cls).setUpClass()
         cls.company_1 = cls.env["res.company"].create({"name": "Test company 1"})
         cls.company_2 = cls.env["res.company"].create({"name": "Test company 2"})
+        cls.alien_companies = cls.env["res.company"].search(
+            [("id", "not in", (cls.company_1 | cls.company_2).ids)]
+        )
         group_account_manager = cls.env.ref("account.group_account_manager")
         group_account_user = cls.env.ref("account.group_account_user")
         group_multi_company = cls.env.ref("base.group_multi_company")
@@ -234,3 +237,52 @@ class TestsProductTaxMulticompany(SavepointCase):
             self.tax_40_cc2,
             "Incorrect taxes when changing it in Company 2",
         )
+
+    def test_divergent_taxes_detection_single_company_product(self):
+        """Divergency detection is skipped in single-company products."""
+        product = (
+            self.env["product.template"]
+            .with_user(self.user_1)
+            .with_context(ignored_company_ids=self.alien_companies.ids)
+            .create(
+                {
+                    "name": "test product",
+                    "supplier_taxes_id": [(6, 0, self.tax_20_sc1.ids)],
+                    "taxes_id": [(6, 0, self.tax_20_cc1.ids)],
+                }
+            )
+        ).sudo()
+        self.assertTrue(product.taxes_id)
+        self.assertTrue(product.supplier_taxes_id)
+        self.assertFalse(product.divergent_company_taxes)
+
+    def test_divergent_taxes_detection_multi_company_product(self):
+        """Divergency detection works as expected in multi-company products."""
+        product = (
+            self.env["product.template"]
+            .with_user(self.user_1)
+            .with_context(ignored_company_ids=self.alien_companies.ids)
+            .create(
+                {
+                    "company_id": False,
+                    "name": "test product",
+                    "supplier_taxes_id": [(6, 0, self.tax_20_sc1.ids)],
+                    "taxes_id": [(6, 0, self.tax_20_cc1.ids)],
+                }
+            )
+        ).sudo()
+        # By default, taxes are propagated
+        self.assertTrue(product.taxes_id)
+        self.assertTrue(product.supplier_taxes_id)
+        self.assertFalse(product.divergent_company_taxes)
+        # Somebody changes taxes in other company
+        product.taxes_id -= self.tax_20_cc2
+        self.assertTrue(product.divergent_company_taxes)
+        # Somebody fixes that again
+        product.set_multicompany_taxes()
+        self.assertFalse(product.divergent_company_taxes)
+        # Same flow with supplier taxes
+        product.supplier_taxes_id -= self.tax_20_sc2
+        self.assertTrue(product.divergent_company_taxes)
+        product.set_multicompany_taxes()
+        self.assertFalse(product.divergent_company_taxes)

--- a/product_tax_multicompany_default/views/product_template_view.xml
+++ b/product_tax_multicompany_default/views/product_template_view.xml
@@ -7,15 +7,39 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="account.product_template_form_view" />
         <field name="groups_id" eval="[(4, ref('account.group_account_user'))]" />
+        <field name="priority" eval="99" />
         <field name="arch" type="xml">
-            <field name="taxes_id" position="after">
-                <button
-                    name="set_multicompany_taxes"
-                    colspan="2"
-                    string="Propagate Taxes"
-                    type="object"
-                />
+            <field name="taxes_id" position="attributes">
+                <attribute name="class" separator=" " add="oe_inline" />
             </field>
+            <field name="taxes_id" position="replace">
+                <label for="taxes_id" />
+                <div name="taxes_id">
+                    <t>$0</t>
+                    <field name="divergent_company_taxes" invisible="True" />
+                    <button
+                        name="set_multicompany_taxes"
+                        icon="fa-clone"
+                        string="Propagate Taxes"
+                        type="object"
+                        class="btn btn-link oe_inline"
+                        attrs="{'invisible':[('divergent_company_taxes', '=', False)]}"
+                    />
+                </div>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.actions.server" id="action_set_multicompany_taxes">
+        <field name="name">Propagate Taxes</field>
+        <field name="model_id" ref="product.model_product_template" />
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('account.group_account_user'))]" />
+        <field name="state">code</field>
+        <field name="code">
+for one in records:
+    one.set_multicompany_taxes()
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Propagate button was ugly. It's prettier now.

  | before | after |
  |--------|--------|
  | ![flameshot_2023-03-21_11-24](https://user-images.githubusercontent.com/973709/226597843-3c070bb1-c103-49aa-bbcd-07ad310ba210.png) | ![flameshot_2023-03-21_11-42](https://user-images.githubusercontent.com/973709/226597888-f094cc22-2654-44fe-9de9-df8dd29c1f36.png) |


- Add ability to filter products that have divergent cross-company taxes.
- Allow propagating massively.

@moduon MT-2586