### PR TITLE
[14.0][FIX] base_multi_company: `no_company_ids` doesn't compute old records when installed

### DIFF
--- a/base_multi_company/hooks.py
+++ b/base_multi_company/hooks.py
@@ -22,7 +22,7 @@ def set_security_rule(env, rule_ref):
         {
             "active": True,
             "domain_force": (
-                "['|', ('no_company_ids', '=', True), ('company_ids', "
+                "['|', ('company_ids', '=', False), ('company_ids', "
                 "'in', company_ids)]"
             ),
         }


### PR DESCRIPTION
# Module `base_multi_company`

The bug is caused by the hook on `base_multi_company`.

When installing a module applying the `base_multi_company` `post_init_hook` it updated all the `company_ids` without using the ORM, modifying it directly with SQL, causing that the `no_company_ids` doesn't compute.

This causes that Odoo shows records that have `company_ids`assigned and `no_company_ids` as True, and only computed correctly if updated the `company_ids` using the ORM.

# Proposed solution
Modify the `set_security_rule` to check if `company_ids` is false directly and not depending on the compute logic of another field `no_company_ids`.

This how Odoo checks the no company assignation without the multi-company assignation.