### PR TITLE
[16.0][FIX] product_tax_multicompany_default: supplier_taxes_id was not found in the form view during tests

### DIFF
--- a/product_tax_multicompany_default/__manifest__.py
+++ b/product_tax_multicompany_default/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/multi-company",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "depends": ["account", "product"],
+    "depends": ["account"],
     "data": ["views/product_template_view.xml"],
     "maintainers": ["Shide"],
 }

--- a/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
+++ b/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
@@ -3,10 +3,13 @@
 # Copyright 2023 Eduardo de Miguel - Moduon Team <edu@moduon.team>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import Form
+import logging
+
+from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase, new_test_user, users
 
 
+@tagged("post_install", "-at_install")
 class TestsProductTaxMulticompany(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -139,6 +142,15 @@ class TestsProductTaxMulticompany(TransactionCase):
 
     @users("user_12")
     def test_set_multicompany_taxes(self):
+        # If purchase module is installed
+        # add purchase manager group to user_12
+        # to access the supplier_taxes_id field in the product view
+        try:
+            self.env.ref(
+                "purchase.group_purchase_manager", raise_if_not_found=True
+            ).sudo().users = [(4, self.user_12.id)]
+        except ValueError as e:
+            logging.info(e)  # Skipping configuration of purchase module
         # Create product with empty taxes
         pf_u3_c1 = Form(self.env["product.product"].with_company(self.company_1))
         pf_u3_c1.name = "Testing Empty Taxes"


### PR DESCRIPTION
The tests on the PR: https://github.com/OCA/multi-company/pull/430 generate the error: https://github.com/OCA/multi-company/actions/runs/4429930504/jobs/7771018405?pr=430

When the purchase module is installed, if the user is not in the 'purchase manager' group then on the product form view, he has no access to the 'supplier_taxes_id' field.

cc @Shide , @pedrobaeza, @Kev-Roche , @sebastienbeau 