### PR TITLE
[IMP] product_tax_multicompany_default: beautier and mass propagation

### DIFF
--- a/product_tax_multicompany_default/readme/USAGE.rst
+++ b/product_tax_multicompany_default/readme/USAGE.rst
@@ -1,9 +1,20 @@
+To propagate taxes in one product:
+
 #. User must have group Full Accounting Features (account.group_account_user)
 #. Go to Invoicing > Customers > Products.
 #. Create a new product and save it.
 #. Switching user company you will see that the product has the default taxes
    for all the companies.
 #. Change tax in a existing product
+#. If Odoo detects divergent taxes across companies, you will see a "Propagate Taxes" button.
 #. Click "Propagate Taxes" button
 #. Switching user company you will see that the product has the same taxes
    for all the companies.
+
+To propagate taxes in mass:
+
+#. User must have group Full Accounting Features (account.group_account_user)
+#. Open products list view.
+#. *Filters > Add custom filter > Has divergent cross-company taxes > is true > Apply*.
+#. Select all products that you want to change.
+#. *Action > Propagate Taxes*.

--- a/product_tax_multicompany_default/views/product_template_view.xml
+++ b/product_tax_multicompany_default/views/product_template_view.xml
@@ -6,16 +6,40 @@
         <field name="name">Product template form (multi-company tax button)</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="account.product_template_form_view" />
+        <field name="priority" eval="99" />
         <field name="arch" type="xml">
-            <field name="taxes_id" position="after">
-                <button
-                    name="set_multicompany_taxes"
-                    colspan="2"
-                    string="Propagate Taxes"
-                    type="object"
-                    groups="account.group_account_user"
-                />
+            <field name="taxes_id" position="attributes">
+                <attribute name="class" separator=" " add="oe_inline" />
             </field>
+            <field name="taxes_id" position="replace">
+                <label for="taxes_id" />
+                <div name="taxes_id">
+                    <t>$0</t>
+                    <field name="divergent_company_taxes" invisible="True" />
+                    <button
+                        name="set_multicompany_taxes"
+                        icon="fa-clone"
+                        string="Propagate Taxes"
+                        type="object"
+                        class="btn btn-link oe_inline"
+                        attrs="{'invisible':[('divergent_company_taxes', '=', False)]}"
+                        groups="account.group_account_user"
+                    />
+                </div>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.actions.server" id="action_set_multicompany_taxes">
+        <field name="name">Propagate Taxes</field>
+        <field name="model_id" ref="product.model_product_template" />
+        <field name="binding_model_id" ref="product.model_product_template" />
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('account.group_account_user'))]" />
+        <field name="state">code</field>
+        <field name="code">
+for one in records:
+    one.set_multicompany_taxes()
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Propagate button was ugly. It's prettier now.
- Add ability to filter products that have divergent cross-company taxes.
- Allow propagating massively.

@moduon MT-2586 forward-port-of #464