### PR TITLE
[12.0][FIX] product_intercompany_account: pass force_company in context

### DIFF
--- a/product_intercompany_account/models/sale_order_line.py
+++ b/product_intercompany_account/models/sale_order_line.py
@@ -1,17 +1,19 @@
-from odoo import models
+from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    @api.multi
     def _prepare_invoice_line(self, qty):
         res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
 
         our_companies = self.env['res.company'].search(
             [('partner_id', '=', self.order_id.partner_id.id)]
         )
-        product_level = self.product_id.property_account_income_intercompany
-        categ = self.product_id.categ_id.property_account_income_categ_intercompany
+        product = self.product_id.with_context(force_company=self.company_id.id)
+        product_level = product.property_account_income_intercompany
+        categ = product.categ_id.property_account_income_categ_intercompany
         if our_companies and (product_level or categ):
             account = product_level or categ
             res.update({'account_id': account.id})


### PR DESCRIPTION
Odoo standard does this:

![Selection_969](https://user-images.githubusercontent.com/25005517/231210827-308e6751-5533-4864-a78b-985e341db90a.png)
