### PR TITLE
[12.0][FIX] product_intercompany_account: sudo when searching companies

### DIFF
--- a/product_intercompany_account/models/account_invoice.py
+++ b/product_intercompany_account/models/account_invoice.py
@@ -6,7 +6,7 @@ class AccountInvoice(models.Model):
 
     def _anglo_saxon_sale_move_lines(self, i_line):
         res = super(AccountInvoice, self)._anglo_saxon_sale_move_lines(i_line)
-        our_companies = self.env['res.company'].search(
+        our_companies = self.env['res.company'].sudo().search(
             [('partner_id', '=', self.partner_id.id)]
         )
         product_level = i_line.product_id.property_account_expense_intercompany
@@ -20,7 +20,7 @@ class AccountInvoice(models.Model):
 
     def _prepare_invoice_line_from_po_line(self, line):
         data = super(AccountInvoice, self)._prepare_invoice_line_from_po_line(line)
-        is_intercompany = self.env['res.company'].search([(
+        is_intercompany = self.env['res.company'].sudo().search([(
             'partner_id', '=', self.partner_id.id,
         )])
 

--- a/product_intercompany_account/models/account_invoice_line.py
+++ b/product_intercompany_account/models/account_invoice_line.py
@@ -10,7 +10,7 @@ class AccountInvoiceLine(models.Model):
             partner = self.invoice_id.partner_id.id
         else:
             partner = self.partner_id.id
-        is_intercompany = self.env['res.company'].search(
+        is_intercompany = self.env['res.company'].sudo().search(
             [('partner_id', '=', partner)]
         )
         if is_intercompany:

--- a/product_intercompany_account/models/sale_order_line.py
+++ b/product_intercompany_account/models/sale_order_line.py
@@ -8,7 +8,7 @@ class SaleOrderLine(models.Model):
     def _prepare_invoice_line(self, qty):
         res = super(SaleOrderLine, self)._prepare_invoice_line(qty)
 
-        our_companies = self.env['res.company'].search(
+        our_companies = self.env['res.company'].sudo().search(
             [('partner_id', '=', self.order_id.partner_id.id)]
         )
         product = self.product_id.with_context(force_company=self.company_id.id)


### PR DESCRIPTION
If self.env.user is not SUPERUSER_ID and the companies are independent (no one is child of the other), then normally a user of company A cannot search for company B. Thus, some flows are wrong without this fix.