### PR TITLE
[14.0][FIX] mail_template_multi_company: Don't set default company on mail template

### DIFF
--- a/mail_template_multi_company/models/mail_template.py
+++ b/mail_template_multi_company/models/mail_template.py
@@ -10,6 +10,5 @@ class MailTemplate(models.Model):
 
     company_id = fields.Many2one(
         "res.company",
-        default=lambda self: self.env.company,
         ondelete="set null",
     )


### PR DESCRIPTION
Fixes #483 

Before this commit, this caused a bug that can be summarised as follows:

1. User A installs mail_template_multi_company.
2. User A installs another module, say, sale.
3. User A creates a new company and sets User B as a member of this (and only this) company.
4. User B tries to send an invoice.

An error occurs at step 4 because of a bug at step 2. At step 2, when the sale module was installed, its mail template (which is used by all companies) defaulted to self.env.company, which was base.main_company. At step 4, using the mail template is forbidden for User B, because the template belongs to a company of which they are not a member.

Removing the default value prevents this problem.