### PR TITLE
[15.0][FIX] account_invoice_inter_company: Avoid crash on False dest_company

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -44,6 +44,8 @@ class AccountMove(models.Model):
             # do not consider invoices that have already been auto-generated,
             # nor the invoices that were already validated in the past
             dest_company = src_invoice._find_company_from_invoice_partner()
+            if not dest_company or src_invoice.auto_generated:
+                continue
             # We want to avoid creating a new invoice if the destination one was already
             # posted
             inter_invoice = self.search(
@@ -53,7 +55,7 @@ class AccountMove(models.Model):
                     ("state", "=", "posted"),
                 ]
             )
-            if not dest_company or src_invoice.auto_generated or inter_invoice:
+            if inter_invoice:
                 continue
             intercompany_user = dest_company.intercompany_invoice_user_id
             if intercompany_user:


### PR DESCRIPTION
If `dest_company` is False, the expression `dest_company.id` fails, so we avoid to enter that code early if no dest_company.

Doing this also, we avoid a useless search.

@Tecnativa TT44078