### PR TITLE
[FIX] base_multi_company: allow reinstalling submodules

### DIFF
--- a/base_multi_company/hooks.py
+++ b/base_multi_company/hooks.py
@@ -51,6 +51,7 @@ def post_init_hook(cr, rule_ref, model_name):
             INSERT INTO {}
             ({}, {})
             SELECT id, company_id FROM {} WHERE company_id IS NOT NULL
+            ON CONFLICT DO NOTHING
         """.format(
             table_name,
             column1,


### PR DESCRIPTION
When a submodule is uninstalled, garbage records are kept with the company relationships.

When you reinstall it, duplicate keys are attempted to be written. Thus, the module cannot be reinstalled without this patch.

@moduon MT-3240