### PR TITLE
[15.0][FIX] account_invoice_inter_company: context can cause a UserError

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -209,6 +209,7 @@ class AccountMove(models.Model):
             .with_company(dest_company.id)
             .with_context(
                 default_move_type=dest_inv_type,
+                default_journal_id=dest_journal.id,
             )
         )
         dest_invoice_data.journal_id = dest_journal


### PR DESCRIPTION
Depending on the path used to reach the invoice, there can be a default_journal_id in the context when the Form object used to create the corresponding invoice on the other company is called. The journal id is typically of the wrong type, which causes a UserError exception to be raised, because the type of the journal and the type of the mirror invoice don't match.

This commit fixes the issue by forcing the journal in the default_journal_id context key in the call the Form