### PR TITLE
purchase_sale_inter_company: fix validation of several picking. self can have more than one record

### DIFF
--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -64,25 +64,18 @@ class StockPicking(models.Model):
 
     def button_validate(self):
         res = super().button_validate()
-        company_obj_sudo = self.env["res.company"].sudo()
-        is_intercompany = company_obj_sudo.search(
-            [("partner_id", "=", self.partner_id.id)]
-        ) or company_obj_sudo.search(
-            [("partner_id", "=", self.partner_id.parent_id.id)]
-        )
-        if (
-            is_intercompany
-            and self.company_id.sync_picking
-            and self.state == "done"
-            and self.picking_type_code == "outgoing"
-        ):
-            sale_order = self.sale_id
-            dest_company = sale_order.partner_id.ref_company_ids
-            for rec in self:
-                if rec.intercompany_picking_id:
-                    rec._sync_receipt_with_delivery(
+        for record in self.sudo():
+            dest_company = record.partner_id.commercial_partner_id.ref_company_ids
+            if (
+                dest_company
+                and dest_company.sync_picking
+                and record.state == "done"
+                and record.picking_type_code == "outgoing"
+            ):
+                if record.intercompany_picking_id:
+                    record._sync_receipt_with_delivery(
                         dest_company,
-                        sale_order,
+                        record.sale_id,
                     )
         return res
 

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -265,6 +265,24 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         self.assertEqual(sale.state, "sale")
         self.assertEqual(sale.partner_id, self.partner_company_a)
 
+    def test_confirm_several_picking(self):
+        """
+        Ensure that confirming several picking is not broken
+        """
+        purchase_1 = self._create_purchase_order(
+            self.partner_company_b, self.consumable_product
+        )
+        purchase_2 = self._create_purchase_order(
+            self.partner_company_b, self.consumable_product
+        )
+        sale_1 = self._approve_po(purchase_1)
+        sale_2 = self._approve_po(purchase_2)
+        pickings = sale_1.picking_ids | sale_2.picking_ids
+        for move in pickings.move_lines:
+            move.quantity_done = move.product_uom_qty
+        pickings.button_validate()
+        self.assertEqual(pickings.mapped("state"), ["done", "done"])
+
     def test_sync_picking(self):
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True


### PR DESCRIPTION
If you try to validate more then one picking.
It will raise an error.
Refactor the code to fix the incompatibility, and clean it to make it simplier and more readable

Fix pr : https://github.com/OCA/multi-company/pull/507