### PR TITLE
[14.0][FIX] when action post an auto_generated invoice browse not made with sudo leads to access rights issues on origin invoice

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -76,12 +76,12 @@ class AccountMove(models.Model):
             # nor the invoices that were already validated in the past
             dest_company = src_invoice._find_company_from_invoice_partner()
             if dest_company:
+                intercompany_user = dest_company.intercompany_invoice_user_id
+                if intercompany_user:
+                    src_invoice = src_invoice.with_user(intercompany_user).sudo()
+                else:
+                    src_invoice = src_invoice.sudo()
                 if not src_invoice.auto_generated:
-                    intercompany_user = dest_company.intercompany_invoice_user_id
-                    if intercompany_user:
-                        src_invoice = src_invoice.with_user(intercompany_user).sudo()
-                    else:
-                        src_invoice = src_invoice.sudo()
                     src_invoice.with_company(dest_company.id).with_context(
                         skip_check_amount_difference=True
                     )._inter_company_create_invoice(dest_company)

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -597,6 +597,8 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
         )
         self.assertEqual(len(bill_a_pdf), 1)
         self.assertEqual(bill_a_pdf.name, invoice_company_b.name + ".pdf")
+        invoice_company_b.button_cancel()
+        invoice_company_b.action_post()
 
     def _confirm_invoice_with_product(self):
         # Confirm the invoice of company A


### PR DESCRIPTION
Hello, 

This is a fix for multi company access issue. 
Without this patch, is you post an auto generated invoice, it will try to generate de pdf on the original invoice but with the wrong user.

We need to change the user even from the auto generated invoice. 