### PR TITLE
[14.0] [FIX] account_invoice_inter_company: Remove self company from eligible companies in `_find_company_from_invoice_partner`

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -57,7 +57,13 @@ class AccountMove(models.Model):
         company = (
             self.env["res.company"]
             .sudo()
-            .search([("partner_id", "=", self.commercial_partner_id.id)], limit=1)
+            .search(
+                [
+                    ("partner_id", "=", self.commercial_partner_id.id),
+                    ("id", "!=", self.company_id.id),
+                ],
+                limit=1,
+            )
         )
         return company or False
 


### PR DESCRIPTION
In some countries (for example, Italy) they need to create invoices to themselves which should not be counted as "inter company invoice"

This PR address that issue, also because, from my prospective, it does not make a lot of sense to create an invoice to yourself and also create the related inter-company invoice as well.