### PR TITLE
[14.0] [FIX] github pre-commit action: pin python version to 3.11 in repository

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v1


### PR DESCRIPTION
As previously stated in https://github.com/OCA/oca-addons-repo-template/pull/214, I'm bringing this change to this repo in version 14.0

CC: @pedrobaeza 