### PR TITLE
[13.0][FIX] account_invoice_inter_company: Check the product with proper company context

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -64,7 +64,12 @@ class AccountMove(models.Model):
                 try:
                     line.sudo(False).product_id.product_tmpl_id.with_user(
                         dest_user
-                    ).check_access_rule("read")
+                    ).with_context(
+                        force_company=dest_company.id,
+                        allowed_company_ids=dest_company.ids,
+                    ).check_access_rule(
+                        "read"
+                    )
                 except AccessError:
                     raise UserError(
                         _(


### PR DESCRIPTION
Not passing through context the corresponding `force_company` and `allowed_company_ids` keys, the check is not done properly in all scenarios.

Steps to reproduce the problem:

- Have `product_multi_company` installed.
- Create a product with no company_ids filled.
- Create a customer invoice from one company to another.
- Try to validate.

Result: The message saying that the product is not multi-company appears.

@Tecnativa TT45745