### PR TITLE
[15.0][FIX] base_multi_company: Proper _check_company when multiple companies selected

### DIFF
--- a/base_multi_company/models/__init__.py
+++ b/base_multi_company/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from . import base
 from . import multi_company_abstract

--- a/base_multi_company/models/base.py
+++ b/base_multi_company/models/base.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Tecnativa - Pedro M. Baeza
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    def _check_company(self, fnames=None):
+        """Inject as context the company of the record that is going to be compared
+        for being taking into account when computing the company of many2one's
+        relations that links with our multi-company models.
+        """
+        company_source_id = False
+        if self._name == "res.company":
+            company_source_id = self.id
+        elif "company_id" in self._fields:
+            company_source_id = self.company_id.id
+        self = self.with_context(_check_company_source_id=company_source_id)
+        return super()._check_company(fnames=fnames)

--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -1,4 +1,5 @@
 # Copyright 2017 LasLabs Inc.
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
@@ -42,12 +43,19 @@ class MultiCompanyAbstract(models.AbstractModel):
         return self.browse(self.env.company.ids)
 
     @api.depends("company_ids")
-    @api.depends_context("company")
+    @api.depends_context("company", "_check_company_source_id")
     def _compute_company_id(self):
         for record in self:
-            # Give the priority of the current company of the user to avoid
-            # multi company incompatibility errors.
-            company_id = self.env.context.get("force_company") or self.env.company.id
+            # Set this priority computing the company (if included in the allowed ones)
+            # for avoiding multi company incompatibility errors:
+            # - If this call is done from method _check_company, the company of the
+            #   record to be compared.
+            # - Otherwise, current company of the user.
+            company_id = (
+                self.env.context.get("_check_company_source_id")
+                or self.env.context.get("force_company")
+                or self.env.company.id
+            )
             if company_id in record.company_ids.ids:
                 record.company_id = company_id
             else:


### PR DESCRIPTION
Forward-port of #535 

Steps to reproduce:

- Create two companies C1 and C2.
- Create a product with C1 and C2 as allowed companies.
- Having C1 as main company, update quantity on hand to 100.
- Switch to C2 as main company, but check the C1 company to be seen as well.
- Now update quantity on hand to any other value for the entry of the company C1.

Result:

'Stock>Inventory adjustment' belongs to company 'C2' and 'Product' (product_id: 'Product 1') belongs to another company.

Explanation:

This is because the computed field `company_id` that is used for checking the product company vs the stock.move company (the error is not accurate, as it says the location, but it's the move), is returning the main company where the user is.

Solution:

Inject a context whenever we run `_check_company` for having available the company involved, and use that company as value for the record being checked if included in the allowed companies.

@Tecnativa 