### PR TITLE
[14.0] [FIX] base_multi_company: apply '_name_search' fix to 'search_read'

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -82,11 +82,9 @@ class MultiCompanyAbstract(models.AbstractModel):
         return super().write(vals)
 
     @api.model
-    def _name_search(
-        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
-    ):
+    def _patch_company_domain(self, args):
         # In some situations the 'in' operator is used with company_id in a
-        # name_search. ORM does not convert to a proper WHERE clause when using
+        # name_search or search_read. ORM does not convert to a proper WHERE clause when using
         # the 'in' operator.
         # e.g: ```
         #     WHERE "res_partner"."id" in (SELECT "res_partner_id"
@@ -114,6 +112,13 @@ class MultiCompanyAbstract(models.AbstractModel):
                 new_args.extend(fix)
             else:
                 new_args.append(arg)
+        return new_args
+
+    @api.model
+    def _name_search(
+        self, name, args=None, operator="ilike", limit=100, name_get_uid=None
+    ):
+        new_args = self._patch_company_domain(args)
         return super()._name_search(
             name,
             args=new_args,
@@ -121,3 +126,8 @@ class MultiCompanyAbstract(models.AbstractModel):
             limit=limit,
             name_get_uid=name_get_uid,
         )
+
+    @api.model
+    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+        new_domain = self._patch_company_domain(domain)
+        return super().search_read(new_domain, fields, offset, limit, order)

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -106,6 +106,20 @@ class TestMultiCompanyAbstract(common.SavepointCase):
         # Result is [(<id>, "test")]
         self.assertEqual(name_result[0][0], self.record_1.id)
 
+        result = self.test_model.search_read(
+            [("company_id", "in", [False, self.company_2.id])], ["name"]
+        )
+        self.assertEqual([{"id": self.record_1.id, "name": self.record_1.name}], result)
+
+    def test_patch_company_domain(self):
+        new_domain = self.test_model._patch_company_domain(
+            [["company_id", "in", [False, self.company_2.id]]]
+        )
+        self.assertEqual(
+            ["|", ["company_id", "=", False], ["company_id", "=", self.company_2.id]],
+            new_domain,
+        )
+
     def test_compute_company_id2(self):
         """
         Test the computation of company_id for a multi_company_abstract.


### PR DESCRIPTION
The same patch applied to `_name_search` could be applied to `search_read`, to fix some different scenarios (e.g. "Search More..." button in m2x relations would open a tree view that applies `search_read` and didn't work before this fix).