### PR TITLE
[15.0][FIX] base_multi_company: _check_company multi-record aware

### DIFF
--- a/base_multi_company/models/base.py
+++ b/base_multi_company/models/base.py
@@ -11,11 +11,16 @@ class Base(models.AbstractModel):
         """Inject as context the company of the record that is going to be compared
         for being taking into account when computing the company of many2one's
         relations that links with our multi-company models.
+
+        We have to serialize the call to super, but it doesn't matter in terms of
+        performance, as super also makes a for loop in the records.
         """
-        company_source_id = False
-        if self._name == "res.company":
-            company_source_id = self.id
-        elif "company_id" in self._fields:
-            company_source_id = self.company_id.id
-        self = self.with_context(_check_company_source_id=company_source_id)
-        return super()._check_company(fnames=fnames)
+        for record in self:
+            company_source_id = False
+            if record._name == "res.company":
+                company_source_id = self.id
+            elif "company_id" in record._fields:
+                company_source_id = record.company_id.id
+            self = self.with_context(_check_company_source_id=company_source_id)
+            super()._check_company(fnames=fnames)
+        return


### PR DESCRIPTION
Follow-up of #535 - Forward-port to v15 of #539

`_check_company` is not an `ensure_one` method, so we need to make sure that if it's called with several records, and they don't belong to the same company, everything is OK.

@Tecnativa 