### PR TITLE
[14.0][FIX]base_multi_company fix singleton   File "/opt/odoo/parts/OCA/mul…

### DIFF
--- a/base_multi_company/models/base.py
+++ b/base_multi_company/models/base.py
@@ -18,7 +18,7 @@ class Base(models.AbstractModel):
         for record in self:
             company_source_id = False
             if record._name == "res.company":
-                company_source_id = self.id
+                company_source_id = record.id
             elif "company_id" in record._fields:
                 company_source_id = record.company_id.id
             self = self.with_context(_check_company_source_id=company_source_id)


### PR DESCRIPTION
Problem with singleton

   res = super().write(values)
  File "/opt/odoo/odoo/odoo/addons/base/models/res_company.py", line 233, in write
    res = super(Company, self).write(values)
  File "/opt/odoo/odoo/odoo/models.py", line 3736, in write
    self._check_company()
  File "/opt/odoo/parts/OCA/multi-company/base_multi_company/models/base.py", line 21, in _check_company
    company_source_id = self.id
  File "/opt/odoo/odoo/odoo/fields.py", line 3825, in __get__
    raise ValueError("Expected singleton: %s" % record)
Exception