### PR TITLE
[16.0][FIX] base_multi_company: Check multiple companies

### DIFF
--- a/base_multi_company/models/base.py
+++ b/base_multi_company/models/base.py
@@ -18,9 +18,9 @@ class Base(models.AbstractModel):
         for record in self:
             company_source_id = False
             if record._name == "res.company":
-                company_source_id = self.id
+                company_source_id = record.id
             elif "company_id" in record._fields:
                 company_source_id = record.company_id.id
-            self = self.with_context(_check_company_source_id=company_source_id)
-            super()._check_company(fnames=fnames)
+            record = record.with_context(_check_company_source_id=company_source_id)
+            super(Base, record)._check_company(fnames=fnames)
         return


### PR DESCRIPTION
Before this PR, executing `_check_company` on multiple companies failed with our beloved
> Expected singleton

error

**Steps**

1. Install **stock**: this module sets `_check_company_auto = True` in https://github.com/odoo/odoo/blob/6485872d00f47e351e40741283f3b9219adcd8a8/addons/stock/models/res_company.py#L9
2. Create multiple companies in one shot with `self.env["res.company"].create([ ... ])` syntax

**Actual behavior**
Error traceback ending with something like
```
  File "/path/to/multi-company/base_multi_company/models/base.py", line 21, in _check_company
    company_source_id = self.id
  File "/path/to/odoo/odoo/fields.py", line 5069, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: res.company(214, 215)
```

**Expected behavior**
No error