### PR TITLE
[16.0][FIX] purchase_sale_inter_company: sync confirmed unlocked purchase updates

### DIFF
--- a/purchase_sale_inter_company/README.rst
+++ b/purchase_sale_inter_company/README.rst
@@ -56,6 +56,15 @@ To configure this module, you need to:
 #. Go to the tab *Inter-Company* then the group *Purchase To Sale*.
 #. If you check the option *Sale Auto Validation* in the configuration of company B, then when you validate a *Purchase Order* in company A with company B as supplier, the *Sale Order* will be automatically validated in company B with company A as customer.
 
+Known issues / Roadmap
+======================
+
+* No synchronization is made from the generated sale order back to the purchase order.
+  This would be interesting in the case of price changes and discounts, that would be
+  transmitted to the purchase so both documents couldn't have different total amounts,
+  taxes, etc. A mechanism for synching from the sale to the purchase order would be
+  needed.
+
 Bug Tracker
 ===========
 

--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -3,12 +3,29 @@
 # Copyright 2018-2019 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
+
+    intercompany_sale_order_id = fields.Many2one(
+        comodel_name="sale.order",
+        compute="_compute_intercompany_sale_order_id",
+        compute_sudo=True,
+    )
+
+    def _compute_intercompany_sale_order_id(self):
+        """A One2many would be simpler, but the record rules make unaccesible for
+        regular users so the logic doesn't work properly"""
+        ids_dict_list = self.env["sale.order"].search_read(
+            [("auto_purchase_order_id", "in", self.ids)],
+            ["id", "auto_purchase_order_id"],
+        )
+        ids_dict = {d["auto_purchase_order_id"][0]: d["id"] for d in ids_dict_list}
+        for order in self:
+            order.intercompany_sale_order_id = ids_dict.get(order.id, False)
 
     def button_approve(self, force=False):
         """Generate inter company sale order base on conditions."""
@@ -176,3 +193,105 @@ class PurchaseOrder(models.Model):
         sale_orders.action_cancel()
         self.write({"partner_ref": False})
         return super().button_cancel()
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    intercompany_sale_line_id = fields.Many2one(
+        comodel_name="sale.order.line",
+        compute="_compute_intercompany_sale_line_id",
+        compute_sudo=True,
+    )
+
+    def _compute_intercompany_sale_line_id(self):
+        """A One2many would be simpler, but the record rules make unaccesible for
+        regular users so the logic doesn't work properly"""
+        ids_dict_list = self.env["sale.order.line"].search_read(
+            [("auto_purchase_line_id", "in", self.ids)], ["id", "auto_purchase_line_id"]
+        )
+        ids_dict = {d["auto_purchase_line_id"][0]: d["id"] for d in ids_dict_list}
+        for line in self:
+            line.intercompany_sale_line_id = ids_dict.get(line.id, False)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Sync lines between an confirmed unlocked purchase and a confirmed unlocked
+        sale order"""
+        lines = super().create(vals_list)
+        for order in lines.order_id.filtered(
+            lambda x: x.state == "purchase" and x.intercompany_sale_order_id
+        ):
+            if order.intercompany_sale_order_id.sudo().state in {"cancel", "done"}:
+                raise UserError(
+                    _(
+                        "You can't change this purchase order as the corresponding "
+                        "sale is %(state)s",
+                        state=order.state,
+                    )
+                )
+            intercompany_user = (
+                order.intercompany_sale_order_id.sudo().company_id.intercompany_sale_user_id
+                or self.env.user
+            )
+            sale_lines = []
+            for purchase_line in lines.filtered(lambda x: x.order_id == order):
+                sale_lines.append(
+                    order._prepare_sale_order_line_data(
+                        purchase_line,
+                        order.intercompany_sale_order_id.sudo().company_id,
+                        order.intercompany_sale_order_id.sudo(),
+                    )
+                )
+            self.env["sale.order.line"].with_user(intercompany_user.id).sudo().create(
+                sale_lines
+            )
+        return lines
+
+    @api.model
+    def _get_purchase_sale_line_sync_fields(self):
+        """Map purchase line fields to the synced sale line peer"""
+        return {
+            "product_qty": "product_uom_qty",
+        }
+
+    def write(self, vals):
+        """Sync values of confirmed unlocked sales"""
+        res = super().write(vals)
+        sync_map = self._get_purchase_sale_line_sync_fields()
+        update_vals = {
+            sync_map.get(field): value
+            for field, value in vals.items()
+            if sync_map.get(field)
+        }
+        if not update_vals:
+            return res
+        intercompany_user = (
+            self.intercompany_sale_line_id.sudo().company_id.intercompany_sale_user_id
+            or self.env.user
+        )
+        sale_lines = self.intercompany_sale_line_id.with_user(
+            intercompany_user.id
+        ).sudo()
+        if not sale_lines:
+            return res
+        closed_sale_lines = sale_lines.filtered(lambda x: x.state != "sale")
+        if closed_sale_lines:
+            raise UserError(
+                _(
+                    "The generated sale orders with reference %(orders)s can't be "
+                    "modified. They're either unconfirmed or locked for modifications.",
+                    orders=",".join(closed_sale_lines.order_id.mapped("name")),
+                )
+            )
+        # Update directly the sale order so we can trigger the decreased qty exceptions
+        for sale in sale_lines.order_id:
+            sale.write(
+                {
+                    "order_line": [
+                        (1, line.id, update_vals)
+                        for line in sale_lines.filtered(lambda x: x.order_id == sale)
+                    ]
+                }
+            )
+        return res

--- a/purchase_sale_inter_company/readme/ROADMAP.rst
+++ b/purchase_sale_inter_company/readme/ROADMAP.rst
@@ -1,0 +1,5 @@
+* No synchronization is made from the generated sale order back to the purchase order.
+  This would be interesting in the case of price changes and discounts, that would be
+  transmitted to the purchase so both documents couldn't have different total amounts,
+  taxes, etc. A mechanism for synching from the sale to the purchase order would be
+  needed.

--- a/purchase_sale_inter_company/static/description/index.html
+++ b/purchase_sale_inter_company/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -383,11 +382,12 @@ It allows to create a sale order in company A from a purchase order in company B
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
 <li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -404,8 +404,18 @@ It allows to create a sale order in company A from a purchase order in company B
 #. Go to the tab <em>Inter-Company</em> then the group <em>Purchase To Sale</em>.
 #. If you check the option <em>Sale Auto Validation</em> in the configuration of company B, then when you validate a <em>Purchase Order</em> in company A with company B as supplier, the <em>Sale Order</em> will be automatically validated in company B with company A as customer.</p>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>No synchronization is made from the generated sale order back to the purchase order.
+This would be interesting in the case of price changes and discounts, that would be
+transmitted to the purchase so both documents couldn’t have different total amounts,
+taxes, etc. A mechanism for synching from the sale to the purchase order would be
+needed.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/multi-company/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -413,9 +423,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Odoo SA</li>
 <li>Akretion</li>
@@ -423,7 +433,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Odoo S.A. (original module <cite>inter_company_rules</cite>)</li>
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
@@ -448,7 +458,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
fw from 

- #559 #561

When the purchase user updates the PO after the SO is generated and always if both are confirmed and unlocked, we sync the new lines to update the demand.

cc @Tecnativa TT46773

please review @pedrobaeza @francesco-ooops
