### PR TITLE
[16.0][FIX] partner_multi_company: Initialize company_ids field

### DIFF
--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -21,6 +21,16 @@ def post_init_hook(cr, registry):
             ),
         }
     )
+    # Initialize m2m table for preserving old restrictions
+    cr.execute(
+        """
+        INSERT INTO res_company_res_partner_rel
+        (res_partner_id, res_company_id)
+        SELECT id, company_id
+        FROM res_partner
+        WHERE company_id IS NOT NULL
+        """
+    )
 
 
 def uninstall_hook(cr, registry):


### PR DESCRIPTION
Preserving those partners that have a restriction on a specific company before installing the module.

@Tecnativa TT46870