### PR TITLE
intercompany_shared_contact: fix wrong field computation and add test

### DIFF
--- a/intercompany_shared_contact/__manifest__.py
+++ b/intercompany_shared_contact/__manifest__.py
@@ -11,6 +11,7 @@
     "version": "14.0.1.1.2",
     "category": "Partner",
     "website": "https://github.com/OCA/multi-company",
+    "maintainers": ["sebastienbeau"],
     "author": "Odoo Community Association (OCA), Akretion",
     "license": "AGPL-3",
     "application": False,

--- a/intercompany_shared_contact/models/res_partner.py
+++ b/intercompany_shared_contact/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
             if record.parent_id.origin_company_id:
                 record.origin_company_id = record.parent_id.origin_company_id
                 record.company_id = False
-            if record.res_company_id:
+            elif record.res_company_id:
                 record.origin_company_id = record.res_company_id
                 record.company_id = False
             else:


### PR DESCRIPTION
origin_company_id was not computed correctly when having parent_id

Add test and fix the bug