### PR TITLE
[14.0] [FIX] product_multi_company: inherit from multi.company.abstract

### DIFF
--- a/product_multi_company/models/product.py
+++ b/product_multi_company/models/product.py
@@ -5,7 +5,8 @@ from odoo import api, fields, models
 
 
 class ProductProduct(models.Model):
-    _inherit = "product.product"
+    _inherit = ["multi.company.abstract", "product.product"]
+    _name = "product.product"
 
     company_ids = fields.Many2many(
         string="Companies",

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -75,3 +75,15 @@ class TestProductMultiCompany(ProductMultiCompanyCommon, common.SavepointCase):
             "('company_id', '=', False)]"
         )
         self.assertEqual(rule.domain_force, domain)
+
+    def test_search_product(self):
+        product_ids = self.env["product.product"].search_read(
+            [["company_id", "=", False]], ["id"]
+        )
+        self.assertIn({"id": self.product_company_none.id}, product_ids)
+
+        product_ids = self.env["product.product"].search_read(
+            [["company_id", "in", [self.company_1.id, False]]], ["id"]
+        )
+        self.assertIn({"id": self.product_company_1.id}, product_ids)
+        self.assertIn({"id": self.product_company_none.id}, product_ids)


### PR DESCRIPTION
Required behavior:
Searching a record with a product that has `check_company=True` without any company assigned must be visible by every company.

Without inheriting `multi.company.abstract` the `product.product` model doesn't use the patched `_name_search` and `search_read`, which is essential if you want to have a relation towards `product.product` with `check_company=True`.

I've also added a test case that practically demonstrate the purpose of this PR and that it would fail without these changes.