### PR TITLE
[15.0][FIX] ``stock_intercompany``: fix unit tests

### DIFF
--- a/stock_intercompany/tests/test_intercompany_picking.py
+++ b/stock_intercompany/tests/test_intercompany_picking.py
@@ -63,13 +63,16 @@ class TestIntercompanyDelivery(TransactionCase):
         self.stock_location = (
             self.env["stock.location"]
             .sudo()
-            .search([("name", "=", "Stock"), ("company_id", "=", self.company1.id)])
+            .search(
+                [("name", "=", "Stock"), ("company_id", "=", self.company1.id)], limit=1
+            )
         )
         self.uom_unit = self.env.ref("uom.product_uom_unit")
 
     def test_picking_creation(self):
         stock_location = self.env["stock.location"].search(
-            [("usage", "=", "internal"), ("company_id", "=", self.company1.id)]
+            [("usage", "=", "internal"), ("company_id", "=", self.company1.id)],
+            limit=1,
         )
         custs_location = self.env.ref("stock.stock_location_customers")
         custs_location.company_id = False


### PR DESCRIPTION
Retrieve singleton, not recordset, via ``stock.location.search()`` before using that location to generate a picking