### PR TITLE
[16.0][IMP] mail_multicompany: add company field in incoming mail servers

### DIFF
--- a/mail_multicompany/README.rst
+++ b/mail_multicompany/README.rst
@@ -28,7 +28,8 @@ Email Gateway Multi company
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds company_id to the models ir.mail_server and mail.message. Also inherits mail.message create function to set the company mail_server.
+This module adds company_id to the models ir.mail_server, mail.message and fetchmail.server. Also inherits mail.message create function to set the company mail_server
+and the mail.thread message_process function to set the correct self.env.company when fetching from the incoming mail servers through a scheduled action.
 
 **Table of contents**
 
@@ -39,6 +40,7 @@ Configuration
 =============
 
 * Go to 'Settings / Technical / Outgoing Mail Servers', and add the company.
+* Go to 'Settings / Technical / Incoming Mail Servers', and add the company.
 
 Usage
 =====
@@ -46,6 +48,7 @@ Usage
 To use this module, you need to:
 
 * Send some email or message that comes out of Odoo.
+* Fetch emails from your mail server into Odoo.
 
 Bug Tracker
 ===========

--- a/mail_multicompany/__manifest__.py
+++ b/mail_multicompany/__manifest__.py
@@ -10,6 +10,10 @@
     "website": "https://github.com/OCA/multi-company",
     "license": "AGPL-3",
     "depends": ["mail"],
-    "data": ["security/mail_security.xml", "views/ir_mail_server_view.xml"],
+    "data": [
+        "security/mail_security.xml",
+        "views/ir_mail_server_view.xml",
+        "views/fetchmail_views.xml",
+    ],
     "installable": True,
 }

--- a/mail_multicompany/models/__init__.py
+++ b/mail_multicompany/models/__init__.py
@@ -2,3 +2,5 @@
 
 from . import ir_mail_server
 from . import mail_message
+from . import fetchmail
+from . import mail_thread

--- a/mail_multicompany/models/fetchmail.py
+++ b/mail_multicompany/models/fetchmail.py
@@ -1,0 +1,10 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class FetchmailServer(models.Model):
+
+    _inherit = "fetchmail.server"
+
+    company_id = fields.Many2one("res.company", "Company")

--- a/mail_multicompany/models/mail_thread.py
+++ b/mail_multicompany/models/mail_thread.py
@@ -1,0 +1,31 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    @api.model
+    def message_process(
+        self,
+        model,
+        message,
+        custom_values=None,
+        save_original=False,
+        strip_attachments=False,
+        thread_id=None,
+    ):
+        context_company = self.env.company
+        server_id = self.env.context.get("default_fetchmail_server_id")
+        server = self.env["fetchmail.server"].browse(server_id)
+        server_company = server.company_id
+        if server_company and server_company != context_company:
+            context_company = server_company
+        return super(MailThread, self.with_company(context_company)).message_process(
+            model, message, custom_values, save_original, strip_attachments, thread_id
+        )

--- a/mail_multicompany/readme/CONFIGURE.rst
+++ b/mail_multicompany/readme/CONFIGURE.rst
@@ -1,1 +1,2 @@
 * Go to 'Settings / Technical / Outgoing Mail Servers', and add the company.
+* Go to 'Settings / Technical / Incoming Mail Servers', and add the company.

--- a/mail_multicompany/readme/DESCRIPTION.rst
+++ b/mail_multicompany/readme/DESCRIPTION.rst
@@ -1,1 +1,2 @@
-This module adds company_id to the models ir.mail_server and mail.message. Also inherits mail.message create function to set the company mail_server.
+This module adds company_id to the models ir.mail_server, mail.message and fetchmail.server. Also inherits mail.message create function to set the company mail_server
+and the mail.thread message_process function to set the correct self.env.company when fetching from the incoming mail servers through a scheduled action.

--- a/mail_multicompany/readme/USAGE.rst
+++ b/mail_multicompany/readme/USAGE.rst
@@ -1,3 +1,4 @@
 To use this module, you need to:
 
 * Send some email or message that comes out of Odoo.
+* Fetch emails from your mail server into Odoo.

--- a/mail_multicompany/security/mail_security.xml
+++ b/mail_multicompany/security/mail_security.xml
@@ -20,4 +20,16 @@
             name="domain_force"
         >['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
     </record>
+    <record model="ir.rule" id="fetchmail_server_rule">
+        <field name="name">fetchmail_server multi-company</field>
+        <field
+            name="model_id"
+            search="[('model','=','fetchmail.server')]"
+            model="ir.model"
+        />
+        <field name="global" eval="True" />
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+    </record>
 </odoo>

--- a/mail_multicompany/static/description/index.html
+++ b/mail_multicompany/static/description/index.html
@@ -369,7 +369,8 @@ ul.auto-toc {
 !! source digest: sha256:c844f628e5f56e26d2ca9490465e79ad1344b3734906420f78571ba6e57c8300
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/multi-company/tree/16.0/mail_multicompany"><img alt="OCA/multi-company" src="https://img.shields.io/badge/github-OCA%2Fmulti--company-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/multi-company-16-0/multi-company-16-0-mail_multicompany"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/multi-company&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module adds company_id to the models ir.mail_server and mail.message. Also inherits mail.message create function to set the company mail_server.</p>
+<p>This module adds company_id to the models ir.mail_server, mail.message and fetchmail.server. Also inherits mail.message create function to set the company mail_server
+and the mail.thread message_process function to set the correct self.env.company when fetching from the incoming mail servers through a scheduled action.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -388,6 +389,7 @@ ul.auto-toc {
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <ul class="simple">
 <li>Go to ‘Settings / Technical / Outgoing Mail Servers’, and add the company.</li>
+<li>Go to ‘Settings / Technical / Incoming Mail Servers’, and add the company.</li>
 </ul>
 </div>
 <div class="section" id="usage">
@@ -395,6 +397,7 @@ ul.auto-toc {
 <p>To use this module, you need to:</p>
 <ul class="simple">
 <li>Send some email or message that comes out of Odoo.</li>
+<li>Fetch emails from your mail server into Odoo.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/mail_multicompany/views/fetchmail_views.xml
+++ b/mail_multicompany/views/fetchmail_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<odoo>
+        <record id="view_email_server_tree_add_company" model="ir.ui.view">
+            <field name="name">fetchmail.server.list.add.company</field>
+            <field name="model">fetchmail.server</field>
+            <field name="inherit_id" ref="mail.view_email_server_tree" />
+            <field name="arch" type="xml">
+                <field name="state" position="after">
+                    <field name="company_id" groups="base.group_multi_company" />
+                </field>
+            </field>
+        </record>
+
+        <record id="view_email_server_form_add_company" model="ir.ui.view">
+            <field name="name">fetchmail.server.form.add.company</field>
+            <field name="model">fetchmail.server</field>
+            <field name="inherit_id" ref="mail.view_email_server_form" />
+            <field name="arch" type="xml">
+                <field name="date" position="after">
+                    <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    options="{'no_create': True}"
+                />
+                </field>
+            </field>
+        </record>
+</odoo>


### PR DESCRIPTION
This commit adds a company_id field to the fetchmail.server model. Then uses this field, in the mail.thread message_process overwritten method, to correctly set the company on the environment when fetching mails.

This change is needed because when fetching the mails with an scheduled action, in an odoo database with multiple companies and multiple outgoing and incoming mail servers, the outgoing mail server of the fetched messages is not being correctly chosen, as the self.env.company is not necessarily the same as the company of the record where the message has to be posted to.