### PR TITLE
[FIX][15.0] purchase_sale_stock_inter_company: Change the action_done to _action_done method.

### DIFF
--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -11,7 +11,7 @@ class StockPicking(models.Model):
 
     intercompany_picking_id = fields.Many2one(comodel_name="stock.picking")
 
-    def action_done(self):
+    def _action_done(self):
         # Only DropShip pickings
         po_picks = self.browse()
         for pick in self.filtered(
@@ -53,5 +53,5 @@ class StockPicking(models.Model):
                     )
         # Transfer dropship pickings
         for po_pick in po_picks.sudo():
-            po_pick.with_company(po_pick.company_id.id).action_done()
-        return super(StockPicking, self).action_done()
+            po_pick.with_company(po_pick.company_id.id)._action_done()
+        return super(StockPicking, self)._action_done()


### PR DESCRIPTION
On the 13 version, it was the action_done method for stock_picking
from 14 onwards, it has been changed to _action_done.

Expected:  when a Delivery order is processed, it should automatically validate the incoming shipment of intercompany 

FYI odoo _action_done method link
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_picking.py#L823
