### PR TITLE
[16.0][IMP-FIX] sale_product_company: define table in m2m model

### DIFF
--- a/sale_product_company/__manifest__.py
+++ b/sale_product_company/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "sale product company",
     "summary": "Set selling companies on product",
-    "version": "16.0.1.0.0",
+    "version": "16.0.2.0.0",
     "development_status": "Alpha",
     "category": "Sale Management",
     "website": "https://github.com/OCA/multi-company",

--- a/sale_product_company/migrations/16.0.2.0.0/pre-migration.py
+++ b/sale_product_company/migrations/16.0.2.0.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.table_exists(env.cr, "product_template_res_company_rel"):
+        return
+    openupgrade.rename_tables(
+        env.cr,
+        [
+            (
+                "product_template_res_company_rel",
+                "product_template_sale_product_company_company_rel",
+            )
+        ],
+    )

--- a/sale_product_company/models/product_template.py
+++ b/sale_product_company/models/product_template.py
@@ -7,7 +7,11 @@ from odoo import api, fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    sale_ok_company_ids = fields.Many2many("res.company", string="Selling Companies")
+    sale_ok_company_ids = fields.Many2many(
+        "res.company",
+        string="Selling Companies",
+        relation="product_template_sale_product_company_company_rel",
+    )
 
     @api.onchange("company_id")
     def _set_sale_ok_company_ids_from_company_id(self):


### PR DESCRIPTION
When defining an m2m template it is convenient to define a unique named table to avoid conflicts with fields from other modules. This module is conflicting with the field of the abstract model ‘multi.company.abstract’ of the module base_multi_company which is extended in the model ‘product.template’ in the module product_multi_company as the same table is defined. To avoid conflicting with this abstract model, the m2m field of this module is renamed.

Error: https://github.com/OCA/multi-company/actions/runs/9205459570/job/25321188163?pr=628#step:8:297

cc @Tecnativa TT48972

@pedrobaeza @carolinafernandez-tecnativa please review