### PR TITLE
[16.0][FIX] sale_product_company: fix test_sale_partner_company

### DIFF
--- a/sale_product_company/tests/test_sale_partner_company.py
+++ b/sale_product_company/tests/test_sale_partner_company.py
@@ -3,7 +3,7 @@
 
 from lxml import etree
 
-from odoo.tests import Form, common
+from odoo.tests import common
 
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
 
@@ -19,9 +19,8 @@ class TestSaleProductCompany(common.TransactionCase):
         company2 = self.env["res.company"].create({"name": "Test Company 2"})
         product = self.env["product.template"].create({"name": "Test Product"})
         product.sale_ok_company_ids = [(6, 0, [company1.id, company2.id])]
-        with Form(product) as product_form:
-            product_form.company_id = company2
-        product = product_form.save()
+        product.company_id = company2
+        product._set_sale_ok_company_ids_from_company_id()
         self.assertEqual(product.sale_ok_company_ids, company2)
 
     def test_sale_product_company(self):


### PR DESCRIPTION
Make tests compatible with other modules that hide the company_id field. For example, product_multi_company hides the company_id field in the form and using Form to run the tests causes a conflict. To solve this, the functionality of the form is replicated directly in the tests without using Form.

Error: https://github.com/OCA/multi-company/actions/runs/9211021131/job/25339390299#step:8:286

cc @Tecnativa TT48972

@pedrobaeza @carolinafernandez-tecnativa please review