### PR TITLE
[16.0][IMP] account_invoice_inter_company: add setting to disable or enable intercompany invoicing

### DIFF
--- a/account_invoice_inter_company/README.rst
+++ b/account_invoice_inter_company/README.rst
@@ -45,7 +45,7 @@ Configuration
 
 To configure this module, you need to go to the menu *Settings > General Settings*, go to the tab *Companies / Inter Company OCA features*
 
-You now have access to other checks *Common Product Catalog* and *Invoice Auto Validation*.
+You now have access to other checks *Common Product Catalog*, *Generate Intercompany Invoices* and *Invoice Auto Validation*.
 
 To customize products sharing don't hesitate to override `_compute_share_product()` in `res.company` model.
 

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -51,6 +51,12 @@ class AccountMove(models.Model):
             dest_company = src_invoice._find_company_from_invoice_partner()
             if not dest_company or src_invoice.auto_generated:
                 continue
+            # If one of the involved companies have the intercompany setting disabled, skip
+            if (
+                not dest_company.intercompany_invoicing
+                or not src_invoice.company_id.intercompany_invoicing
+            ):
+                continue
             intercompany_user = dest_company.intercompany_invoice_user_id
             if intercompany_user:
                 src_invoice = src_invoice.with_user(intercompany_user).sudo()

--- a/account_invoice_inter_company/models/res_company.py
+++ b/account_invoice_inter_company/models/res_company.py
@@ -29,6 +29,14 @@ class ResCompany(models.Model):
         help="Responsible user for creation of invoices triggered by "
         "intercompany rules.",
     )
+    intercompany_invoicing = fields.Boolean(
+        string="Generate Inter company Invoices",
+        help="Enable intercompany invoicing: "
+        "\n* Generate a Customer Invoice when a bill with this company is created."
+        "\n* Generate a Vendor Bill when an invoice with this company as a customer"
+        " is created.",
+        default=True,
+    )
 
     def _compute_share_product(self):
         product_rule = self.env.ref("product.product_comp_rule")

--- a/account_invoice_inter_company/models/res_config_settings.py
+++ b/account_invoice_inter_company/models/res_config_settings.py
@@ -31,6 +31,16 @@ class ResConfigSettings(models.TransientModel):
         "company are visible for all companies.",
     )
 
+    intercompany_invoicing = fields.Boolean(
+        string="Generate Inter company Invoices",
+        related="company_id.intercompany_invoicing",
+        help="Enable intercompany invoicing: "
+        "\n * Generate a Customer Invoice when a bill with this company is created."
+        "\n * Generate a Vendor Bill when an invoice with this company as a customer"
+        " is created.",
+        readonly=False,
+    )
+
     @api.model
     def get_values(self):
         res = super().get_values()

--- a/account_invoice_inter_company/readme/CONFIGURE.rst
+++ b/account_invoice_inter_company/readme/CONFIGURE.rst
@@ -1,5 +1,5 @@
 To configure this module, you need to go to the menu *Settings > General Settings*, go to the tab *Companies / Inter Company OCA features*
 
-You now have access to other checks *Common Product Catalog* and *Invoice Auto Validation*.
+You now have access to other checks *Common Product Catalog*, *Generate Intercompany Invoices* and *Invoice Auto Validation*.
 
 To customize products sharing don't hesitate to override `_compute_share_product()` in `res.company` model.

--- a/account_invoice_inter_company/static/description/index.html
+++ b/account_invoice_inter_company/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -392,7 +391,7 @@ Second scenario: company A create an invoice with company B as supplier. The mod
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p>To configure this module, you need to go to the menu <em>Settings &gt; General Settings</em>, go to the tab <em>Companies / Inter Company OCA features</em></p>
-<p>You now have access to other checks <em>Common Product Catalog</em> and <em>Invoice Auto Validation</em>.</p>
+<p>You now have access to other checks <em>Common Product Catalog</em>, <em>Generate Intercompany Invoices</em> and <em>Invoice Auto Validation</em>.</p>
 <p>To customize products sharing don’t hesitate to override <cite>_compute_share_product()</cite> in <cite>res.company</cite> model.</p>
 </div>
 <div class="section" id="known-issues-roadmap">

--- a/account_invoice_inter_company/views/res_config_settings_view.xml
+++ b/account_invoice_inter_company/views/res_config_settings_view.xml
@@ -33,7 +33,18 @@
                     <div class="o_setting_left_pane" />
                     <div class="o_setting_right_pane">
                         <div class="o_form_label mt8">Invoicing</div>
-                        <div id="intercompany_invoice_user">
+                        <div id="intercompany_invoicing">
+                            <field name="intercompany_invoicing" class="oe_inline" />
+                            <label
+                                string="Generate Intercompany Invoices"
+                                class="o_light_label"
+                                for="intercompany_invoicing"
+                            />
+                        </div>
+                        <div
+                            id="intercompany_invoice_user"
+                            attrs="{'invisible': [('intercompany_invoicing', '=', False)]}"
+                        >
                             <label
                                 string="Intercompany user for invoices"
                                 class="o_light_label"
@@ -44,7 +55,10 @@
                                 class="oe_inline"
                             />
                         </div>
-                        <div id="inter_company_invoice_validation">
+                        <div
+                            id="inter_company_invoice_validation"
+                            attrs="{'invisible': [('intercompany_invoicing', '=', False)]}"
+                        >
                             <field name="invoice_auto_validation" class="oe_inline" />
                             <label
                                 string="Invoice Auto Validation"


### PR DESCRIPTION
This PR adds a new setting called intercompany_invoicing that allows the user to activate or deactivate the intercompany invoicing. When positing an intercompany invoice, if one of the companies have the setting disabled, the other invoice will not be automatically created.