### PR TITLE
[16.0][IMP] stock_intercompany_bidirectional: change default stock location

### DIFF
--- a/stock_intercompany/models/stock_picking.py
+++ b/stock_intercompany/models/stock_picking.py
@@ -41,7 +41,8 @@ class StockPicking(models.Model):
             "picking_type_id": ptype.id,
             "state": "draft",
             "location_id": self.env.ref("stock.stock_location_suppliers").id,
-            "location_dest_id": warehouse.lot_stock_id.id,
+            "location_dest_id": ptype.default_location_dest_id.id
+            or warehouse.lot_stock_id.id,
             "counterpart_of_picking_id": self.id,
             "move_ids": move_ids,
             "move_line_ids": move_line_ids,

--- a/stock_intercompany_bidirectional/models/stock_picking.py
+++ b/stock_intercompany_bidirectional/models/stock_picking.py
@@ -39,13 +39,16 @@ class StockPickingIntercompanyBidirectional(models.Model):
         move_ids, move_line_ids = super()._check_company_consistency(company)
 
         warehouse = company.intercompany_in_type_id.warehouse_id
+        location_dest = company.intercompany_in_type_id.default_location_dest_id
         stock_move_line_obj = self.env["stock.move.line"]
 
         # Remove package-related data and update destination location
         # in move_ids and move_line_ids
         for move_data in move_ids:
             # Update destination location for each move
-            move_data[2]["location_dest_id"] = warehouse.lot_stock_id.id
+            move_data[2]["location_dest_id"] = (
+                location_dest.id or warehouse.lot_stock_id.id
+            )
             # Set rule_id to False
             move_data[2]["rule_id"] = False
         for line_data in move_line_ids:
@@ -54,7 +57,7 @@ class StockPickingIntercompanyBidirectional(models.Model):
                 {
                     "package_level_id": False,
                     "package_id": False,
-                    "location_dest_id": warehouse.lot_stock_id.id,
+                    "location_dest_id": location_dest.id or warehouse.lot_stock_id.id,
                 }
             )
 


### PR DESCRIPTION
… for counterpart company.

Context:
Module set counterpart company default incoming location as a warehouse stock 'lot_stock_id'. However, the incoming intercompany transfer must be processed with the 'Intercompany Operation Type IN' operation type default destination set.  

Current Behavior:
Counterpart picking is created with the default destination set as the operation type warehouse stock location.

Expected behaviour:
Counterpart picking is created with the default destination set as the operation type default destination location set with the 'Intercompany Operation Type IN' 