### PR TITLE
[14.0][FIX] Picking sync should also work for dropshipping

### DIFF
--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -94,7 +94,9 @@ class StockPicking(models.Model):
     def button_validate(self):
         res = super().button_validate()
         for record in self.sudo():
-            dest_company = record.partner_id.commercial_partner_id.ref_company_ids
+            dest_company = (
+                record.sale_id.partner_id.commercial_partner_id.ref_company_ids
+            )
             if (
                 dest_company
                 and dest_company.sync_picking


### PR DESCRIPTION
In case of dropshipping, picking.partner_id is the end customer (picking.sale_id.partner_shipping_id) so this partner's ref_company_ids will be empty and the picking will not sync. Use sale_id.partner_id instead, which is always the intercompany partner.