### PR TITLE
[14.0] Dont force Done state on PO picking

### DIFF
--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -36,6 +36,13 @@ class ResCompany(models.Model):
         help="Sync the receipt from the destination company with the "
         "delivery from the source company",
     )
+    sync_picking_state = fields.Boolean(
+        string="Sync the receipt state with the delivery state",
+        default=lambda p: p.sync_picking,
+        help="State of receipt picking syncs with state of the delivery "
+        "from the source company. Note this disallows user to manually "
+        "correct or change a picking that did not sync properly.",
+    )
     block_po_manual_picking_validation = fields.Boolean(
         string="Block manual validation of picking in the destination company",
     )

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -47,6 +47,10 @@ class InterCompanyRulesConfig(models.TransientModel):
         "the delivery from the source company",
         readonly=False,
     )
+    sync_picking_state = fields.Boolean(
+        related="company_id.sync_picking_state",
+        readonly=False,
+    )
     block_po_manual_picking_validation = fields.Boolean(
         related="company_id.block_po_manual_picking_validation",
         readonly=False,

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -21,7 +21,8 @@ class StockPicking(models.Model):
         res = super()._compute_state()
         for picking in self:
             if (
-                picking.intercompany_picking_id
+                picking.company_id.sync_picking_state
+                and picking.intercompany_picking_id
                 and picking.picking_type_code == "incoming"
                 and picking.state not in ["done", "cancel"]
             ):

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -354,14 +354,16 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             so_picking_id.move_lines.product_qty,
         )
 
-        so_picking_id.state = "done"
+        # Validate sale order, create backorder
         wizard_data = so_picking_id.with_user(self.user_company_b).button_validate()
         wizard = (
             self.env["stock.backorder.confirmation"]
             .with_context(**wizard_data.get("context"))
             .create({})
         )
-        wizard.process()
+        wizard.with_user(self.user_company_b).process()
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertNotEqual((sale.picking_ids - so_picking_id).state, "done")
 
         # Quantities should have been synced
         self.assertNotEqual(po_picking_id, so_picking_id)
@@ -393,7 +395,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         self.company_b.sync_picking = True
 
         purchase = self._create_purchase_order(
-            self.partner_company_b, self.stockable_product_serial
+            self.partner_company_b,
+            self.stockable_product_serial + self.consumable_product,
         )
         sale = self._approve_po(purchase)
 
@@ -401,14 +404,15 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         po_picking_id = purchase.picking_ids
         so_picking_id = sale.picking_ids
 
-        so_move = so_picking_id.move_lines
-        so_move.move_line_ids = [
+        so_moves = so_picking_id.move_lines
+        so_moves[1].quantity_done = 2
+        so_moves[0].move_line_ids = [
             (
                 0,
                 0,
                 {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
+                    "location_id": so_moves[0].location_id.id,
+                    "location_dest_id": so_moves[0].location_dest_id.id,
                     "product_id": self.stockable_product_serial.id,
                     "product_uom_id": self.stockable_product_serial.uom_id.id,
                     "qty_done": 1,
@@ -420,21 +424,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 0,
                 0,
                 {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "qty_done": 1,
-                    "lot_id": self.serial_2.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
-            (
-                0,
-                0,
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
+                    "location_id": so_moves[0].location_id.id,
+                    "location_dest_id": so_moves[0].location_dest_id.id,
                     "product_id": self.stockable_product_serial.id,
                     "product_uom_id": self.stockable_product_serial.uom_id.id,
                     "qty_done": 1,
@@ -443,9 +434,17 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 },
             ),
         ]
-        so_picking_id.button_validate()
+        wizard_data = so_picking_id.with_user(self.user_company_b).button_validate()
+        wizard = (
+            self.env["stock.backorder.confirmation"]
+            .with_context(**wizard_data.get("context"))
+            .create({})
+        )
+        wizard.with_user(self.user_company_b).process()
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertNotEqual((sale.picking_ids - so_picking_id).state, "done")
 
-        so_lots = so_move.mapped("move_line_ids.lot_id")
+        so_lots = so_moves.mapped("move_line_ids.lot_id")
         po_lots = po_picking_id.mapped("move_lines.move_line_ids.lot_id")
         self.assertEqual(
             len(so_lots),
@@ -456,8 +455,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             so_lots, po_lots, msg="The lots of the moves should be different objects"
         )
         self.assertEqual(
-            so_lots.mapped("name"),
-            po_lots.mapped("name"),
+            so_lots.sudo().mapped("name"),
+            po_lots.sudo().mapped("name"),
             msg="The lots should have the same name in both moves",
         )
         self.assertIn(
@@ -465,6 +464,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             po_lots,
             msg="Serial 333 already existed, a new one shouldn't have been created",
         )
+        # A backorder should have been made for both
+        self.assertTrue(len(sale.picking_ids) > 1)
+        self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
 
     def test_sync_picking_same_product_multiple_lines(self):
         """

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -326,6 +326,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
     def test_sync_picking(self):
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
 
         purchase = self._create_purchase_order(
             self.partner_company_b, self.consumable_product
@@ -378,6 +380,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         # A backorder should have been made for both
         self.assertTrue(len(sale.picking_ids) > 1)
         self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
+        # The original orders should now be done.
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertEqual(po_picking_id.state, "done")
 
     def test_sync_picking_lot(self):
         """
@@ -393,6 +398,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         )
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
 
         purchase = self._create_purchase_order(
             self.partner_company_b,
@@ -467,6 +474,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         # A backorder should have been made for both
         self.assertTrue(len(sale.picking_ids) > 1)
         self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
+        # The original orders should now be done.
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertEqual(po_picking_id.state, "done")
 
     def test_sync_picking_same_product_multiple_lines(self):
         """
@@ -599,6 +609,10 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 "3.0 Units of Consumable Product 2.+instead of 8.0 Units", re.DOTALL
             ),
         )
+        print(so_picking_id.state)
+        po_picking_id = purchase.picking_ids
+        print(po_picking_id.state)
+        # Upon confirm, I expect here an issue
 
     def test_block_manual_validation(self):
         """

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -621,6 +621,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         """
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
         self.company_a.block_po_manual_picking_validation = True
         self.company_b.block_po_manual_picking_validation = True
         purchase = self._create_purchase_order(

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -45,6 +45,13 @@
                         for="sync_picking"
                     />
                     <br />
+                    <field name="sync_picking_state" class="oe_inline" />
+                    <label
+                        string="Sync picking state"
+                        class="o_light_label"
+                        for="sync_picking_state"
+                    />
+                    <br />
                     <field
                         name="block_po_manual_picking_validation"
                         class="oe_inline"


### PR DESCRIPTION
Currently the code forces PO picking state to Done when SO picking is done, but this can be harmful:

- If there was a mismatch in SO and PO move lines, activity is created for user to fix, but picking is already set to Done, then user can't correct anything

------------------------

I do think this is a good idea because the PO picking state should IMO never be force-set to Done; better behaviour is that the move lines are processed like they should and then the picking will automatically be set to Done when everything is in order; if not, it should leave the picking open and create an activity for a user.

MR is still set to Draft because:

- I don't know if this is actually a case that happens in real life of if it was caused by https://github.com/OCA/multi-company/pull/646 or https://github.com/OCA/stock-logistics-warehouse/pull/2025
- Because of the above I also can't make tests, because I fail to reproduce a case where this would be needed
