### PR TITLE
[FIX] purchase_sale_inter_company: support discount

### DIFF
--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -20,7 +20,13 @@ class SaleOrder(models.Model):
         for order in self.filtered("auto_purchase_order_id"):
             for line in order.order_line.sudo():
                 if line.auto_purchase_line_id:
-                    line.auto_purchase_line_id.price_unit = line.price_unit
+                    qty = line.product_uom_qty
+                    if qty:
+                        line.auto_purchase_line_id.price_unit = (
+                            line.price_subtotal / qty
+                        )
+                    else:
+                        line.auto_purchase_line_id.price_unit = 0.0
         res = super().action_confirm()
         for sale_order in self.sudo():
             dest_company = sale_order.partner_id.ref_company_ids

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -292,8 +292,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
     def test_so_change_price(self):
         sale = self._approve_po(self.purchase_company_a)
         sale.order_line.price_unit = 10
+        sale.order_line.discount = 10.0
         sale.action_confirm()
-        self.assertEqual(self.purchase_company_a.order_line.price_unit, 10)
+        self.assertEqual(self.purchase_company_a.order_line.price_unit, 9)
 
     def test_po_with_contact_as_partner(self):
         contact = self.env["res.partner"].create(


### PR DESCRIPTION
Currently when the sale order line has received a discount, and the SO is confirmed, the undiscounted price is copied over to the PO, leading to a price discrepancy between the SO and PO. With this commit, discount is respected.