### PR TITLE
[15.0][IMP] partner_multi_company: prevent inconsistencies between user and partner

### DIFF
--- a/partner_multi_company/__manifest__.py
+++ b/partner_multi_company/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Partner multi-company",
     "summary": "Select individually the partner visibility on each company",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "license": "AGPL-3",
     "depends": ["base_multi_company"],
     "author": "Tecnativa, " "Odoo Community Association (OCA)",

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -16,6 +16,19 @@ def post_init_hook(cr, registry):
         "base.res_partner_rule",
         "res.partner",
     )
+    fix_user_partner_companies(cr)
+
+
+def fix_user_partner_companies(cr):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    for user in env["res.users"].search([]):
+        user_company_ids = set(user.company_ids.ids)
+        partner_company_ids = set(user.partner_id.company_ids.ids)
+        if not user_company_ids.issubset(partner_company_ids) and partner_company_ids:
+            missing_company_ids = list(user_company_ids - partner_company_ids)
+            user.partner_id.write(
+                {"company_ids": [(4, company_id) for company_id in missing_company_ids]}
+            )
 
 
 def uninstall_hook(cr, registry):

--- a/partner_multi_company/migrations/15.0.1.1.0/post-migration.py
+++ b/partner_multi_company/migrations/15.0.1.1.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2024 ForgeFlow S.L. (http://www.forgeflow.com)
+# Copyright 2024 ForgeFlow S.L. (http://www.forgeflow.com)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+# pylint: disable=W7950
+from odoo.addons.partner_multi_company import hooks
+
+
+def migrate(cr, version):
+    hooks.fix_user_partner_companies(cr)

--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -2,7 +2,8 @@
 # Copyright 2015-2019 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html.html
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -58,3 +59,33 @@ class ResPartner(models.Model):
         elif "company_id" not in vals:
             vals["company_ids"] = False
         return vals
+
+    @api.constrains("company_ids")
+    def _check_company_id(self):
+        for rec in self:
+            if rec.user_ids:
+                user_company_ids = set(rec.user_ids.mapped("company_ids").ids)
+                partner_company_ids = set(rec.company_ids.ids)
+
+                if (
+                    not user_company_ids.issubset(partner_company_ids)
+                    and partner_company_ids
+                ):
+                    raise ValidationError(
+                        _(
+                            "The partner must have at least all the companies "
+                            "associated with the user."
+                        )
+                    )
+
+    def _inverse_company_id(self):
+        if self.env.context.get("from_res_users"):
+            # don't delete all partner company_ids when
+            # the user's related company_id is modified.
+            for record in self:
+                company = record.company_id
+                if company:
+                    record.company_ids = [(4, company.id)]
+            return
+        else:
+            return super()._inverse_company_id()

--- a/partner_multi_company/models/res_users.py
+++ b/partner_multi_company/models/res_users.py
@@ -12,16 +12,28 @@ class ResUsers(models.Model):
         res = super(ResUsers, self).create(vals)
         if "company_ids" in vals:
             res.partner_id.company_ids = vals["company_ids"]
-        if "company_id" in vals and res.partner_id.company_ids:
-            res.partner_id.company_id = vals["company_id"]
         return res
 
     def write(self, vals):
-        res = super(ResUsers, self).write(vals)
+        res = super(ResUsers, self.with_context(from_res_users=True)).write(vals)
         if "company_ids" in vals:
             for user in self.sudo():
-                if user.partner_id.company_ids:
-                    user.partner_id.company_ids = vals["company_ids"]
+                new_company_ids = []
+                company_ids_data = vals["company_ids"]
+                if isinstance(company_ids_data, list) and user.partner_id.company_ids:
+                    for item in company_ids_data:
+                        if isinstance(item, tuple):
+                            if item[0] == 4:
+                                new_company_ids.append(item[1])
+                            elif item[0] == 6:
+                                new_company_ids.extend(item[2])
+                        elif isinstance(item, list):
+                            new_company_ids = item[2]
+                        else:
+                            new_company_ids.append(item)
+                    user.partner_id.company_ids = [
+                        (4, company_id) for company_id in new_company_ids
+                    ]
         if "company_id" in vals:
             for user in self.sudo():
                 if user.partner_id.company_ids:

--- a/partner_multi_company/static/description/index.html
+++ b/partner_multi_company/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -438,7 +438,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/res_company_code/demo/res_company.xml
+++ b/res_company_code/demo/res_company.xml
@@ -19,4 +19,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
     <record id="base.main_company" model="res.company">
         <field name="code">C1</field>
     </record>
+    <record model="res.partner" id="base.partner_demo">
+        <field name="company_id" eval="False" />
+    </record>
 </odoo>


### PR DESCRIPTION
This improvement prevent some inconsistencies between user and partner company_ids

- If you try to modify the partner companies and the user companies are not included in the partner companies,  an error will be raised.
- If the user's companies are modified, they will be added to the partner while retaining the companies the partner already has.
- Don't delete all partner company_ids when the user's related company_id is modified.

The change on the res_company_code was needed in order to pass odoo tests