### PR TITLE
[15.0][FIX] product_multi_company: do not allow to remove company if there is stock or moves in that company

### DIFF
--- a/product_multi_company/models/product_template.py
+++ b/product_multi_company/models/product_template.py
@@ -1,10 +1,95 @@
 # Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import models
+from odoo import _, models
+from odoo.exceptions import UserError
 
 
 class ProductTemplate(models.Model):
     _inherit = ["multi.company.abstract", "product.template"]
     _name = "product.template"
     _description = "Product Template (Multi-Company)"
+
+    def _get_companies_to_remove(self, new_company_ids):
+        companies_to_remove = []
+        for command in new_company_ids:
+            if command[0] == 3:
+                companies_to_remove.append(command[1])
+            elif command[0] == 6:
+                if not command[2]:
+                    return False  # If the list is empty, it means all companies are allowed
+                if self.company_ids:
+                    companies_to_remove = [
+                        id for id in self.company_ids.ids if id not in command[2]
+                    ]
+                else:
+                    companies_to_remove = [
+                        id
+                        for id in self.env["res.company"].search([]).ids
+                        if id not in command[2]
+                    ]
+        return companies_to_remove
+
+    def write(self, vals):
+        if "company_ids" in vals:
+            new_company_ids = vals.get("company_ids", [])
+            companies_to_remove = self._get_companies_to_remove(new_company_ids)
+            if companies_to_remove:
+                products_to_check = self.filtered(
+                    lambda product: not product.company_ids
+                    or any(
+                        company.id in companies_to_remove
+                        for company in product.company_ids
+                    )
+                )
+                if products_to_check:
+                    move = (
+                        self.env["stock.move"]
+                        .sudo()
+                        .search(
+                            [
+                                (
+                                    "product_id",
+                                    "in",
+                                    products_to_check.product_variant_ids.ids,
+                                ),
+                                ("company_id", "in", companies_to_remove),
+                            ],
+                            order=None,
+                            limit=1,
+                        )
+                    )
+                    if move:
+                        raise UserError(
+                            _(
+                                "This product's company cannot be removed as long as "
+                                "there are stock moves of it belonging "
+                                "to the company being removed."
+                            )
+                        )
+                    quant = (
+                        self.env["stock.quant"]
+                        .sudo()
+                        .search(
+                            [
+                                (
+                                    "product_id",
+                                    "in",
+                                    products_to_check.product_variant_ids.ids,
+                                ),
+                                ("company_id", "in", companies_to_remove),
+                                ("quantity", "!=", 0),
+                            ],
+                            order=None,
+                            limit=1,
+                        )
+                    )
+                    if quant:
+                        raise UserError(
+                            _(
+                                "This product's company cannot be removed as long as "
+                                "there are quantities of it belonging "
+                                "to the company being removed."
+                            )
+                        )
+        return super().write(vals)

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -2,7 +2,8 @@
 # Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
+from odoo.fields import Command
 from odoo.tests import common
 
 from .common import ProductMultiCompanyCommon
@@ -70,3 +71,102 @@ class TestProductMultiCompany(ProductMultiCompanyCommon, common.TransactionCase)
             "('company_id', '=', False)]"
         )
         self.assertEqual(rule.domain_force, domain)
+
+    def test_allow_company_change(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "type": "product",
+                "company_ids": [(6, 0, [self.company_1.id, self.company_2.id])],
+            }
+        )
+        product.write({"company_ids": [(3, self.company_2.id)]})
+        self.assertNotIn(self.company_2.id, product.company_ids.ids)
+        self.assertIn(self.company_1.id, product.company_ids.ids)
+
+    def test_prevent_company_change_with_stock_moves(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product with Moves",
+                "type": "product",
+                "company_ids": [(6, 0, [self.company_1.id, self.company_2.id])],
+            }
+        )
+        self.env["stock.move"].create(
+            {
+                "name": "Test Move",
+                "product_id": product.id,
+                "company_id": self.company_2.id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "product_uom_qty": 10,
+                "product_uom": self.env.ref("uom.product_uom_unit").id,
+            }
+        )
+        with self.assertRaises(UserError):
+            product.company_ids = self.company_1
+
+    def test_prevent_company_change_with_quantities(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product with Quantities",
+                "type": "product",
+                "company_ids": [(6, 0, [self.company_1.id, self.company_2.id])],
+            }
+        )
+        location_company_2 = self.env["stock.location"].create(
+            {
+                "name": "Company 2 Stock Location",
+                "usage": "internal",
+                "company_id": self.company_2.id,
+            }
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "company_id": self.company_2.id,
+                "location_id": location_company_2.id,
+                "quantity": 10,
+            }
+        )
+        with self.assertRaises(UserError):
+            product.write({"company_ids": [(3, self.company_2.id)]})
+
+    def test_replace_company_ids(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product with Quantities",
+                "type": "product",
+                "company_ids": [(6, 0, [self.company_1.id, self.company_2.id])],
+            }
+        )
+        location_company_2 = self.env["stock.location"].create(
+            {
+                "name": "Company 2 Stock Location",
+                "usage": "internal",
+                "company_id": self.company_2.id,
+            }
+        )
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "company_id": self.company_2.id,
+                "location_id": location_company_2.id,
+                "quantity": 10,
+            }
+        )
+        with self.assertRaises(UserError):
+            product.write({"company_ids": [Command.set([self.company_1.id])]})
+
+    def test_allow_all_companies(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product All Companies",
+                "type": "product",
+                "company_ids": [(6, 0, [self.company_1.id])],
+            }
+        )
+        # Setting company_ids to False (allow all companies)
+        product.company_ids = False
+        self.assertFalse(product.company_ids)
+        product.write({"company_ids": [Command.link(self.company_1.id)]})


### PR DESCRIPTION
This fix addresses the issue where companies could be removed from a product's company_ids field even when there are existing stock quantities or stock moves associated with that company. The update adds validation checks to prevent the removal of a company under these conditions, ensuring data integrity and preventing potential inconsistencies