### PR TITLE
[13.0][FIX] purchase_sale_inter_company: Use the correct function name to link the invoice with purchase order.

### DIFF
--- a/purchase_sale_inter_company/models/account_move.py
+++ b/purchase_sale_inter_company/models/account_move.py
@@ -9,13 +9,9 @@ from odoo import _, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def inter_company_create_invoice(
-        self, dest_company, dest_inv_type, dest_journal_type
-    ):
-        res = super().inter_company_create_invoice(
-            dest_company, dest_inv_type, dest_journal_type
-        )
-        if dest_inv_type == "in_invoice":
+    def _inter_company_create_invoice(self, dest_company):
+        res = super()._inter_company_create_invoice(dest_company)
+        if res["dest_invoice"].type == "in_invoice":
             # Link intercompany purchase order with intercompany invoice
             self._link_invoice_purchase(res["dest_invoice"])
         return res
@@ -24,8 +20,6 @@ class AccountMove(models.Model):
         self.ensure_one()
         orders = self.env["purchase.order"]
         vals = {}
-        if dest_invoice.state not in ["draft", "cancel"]:
-            vals["invoiced"] = True
         for line in dest_invoice.invoice_line_ids:
             vals["invoice_lines"] = [(4, line.id)]
             purchase_lines = line.auto_invoice_line_id.sale_line_ids.mapped(

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -210,15 +210,14 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
 
     def test_purchase_invoice_relation(self):
         sale = self._approve_po(self.purchase_company_a)
-        sale_invoice_id = sale._create_invoices()[0]
-        sale_invoice_id.action_post()
-        self.assertEquals(
-            sale_invoice_id.auto_invoice_id, self.purchase_company_a.invoice_ids,
+        sale_invoice = sale._create_invoices()[0]
+        sale_invoice.action_post()
+        self.assertEqual(len(self.purchase_company_a.invoice_ids), 1)
+        self.assertEqual(
+            self.purchase_company_a.invoice_ids.auto_invoice_id, sale_invoice,
         )
-        self.assertEquals(
-            sale_invoice_id.auto_invoice_id.invoice_line_ids,
-            self.purchase_company_a.order_line.invoice_lines,
-        )
+        self.assertEqual(len(self.purchase_company_a.order_line.invoice_lines), 1)
+        self.assertEqual(self.purchase_company_a.order_line.qty_invoiced, 3)
 
     def test_cancel(self):
         self.company_b.sale_auto_validation = False


### PR DESCRIPTION
Before this commit, when an invoice was created, it was never linked with the  purchase order because the function name was incorrect After this commit, the invoice and purchase are linked correctly see function name here https://github.com/OCA/multi-company/blob/473aa18b9286dcd8650d7e51dcdb07295e972aac/account_invoice_inter_company/models/account_move.py#L82

@Tecnativa TT46194
@carolinafernandez-tecnativa  @pedrobaeza could you please review this PR