### PR TITLE
[15.0][IMP] Don't update session_info if display_switch_company_menu unset.

### DIFF
--- a/res_company_code/models/ir_http.py
+++ b/res_company_code/models/ir_http.py
@@ -13,24 +13,22 @@ class Http(models.AbstractModel):
         result = super().session_info()
         user = request.env.user
 
-        display_switch_company_menu = (
-            user.has_group("base.group_multi_company") and len(user.company_ids) > 1
-        )
+        if user.has_group("base.group_multi_company") and len(user.company_ids) > 1:
+            # Replace company name by company complete name in the session
+            # The values are used in the switch_company_menu widget (web module)
+            result["user_companies"]["current_company"] = user.company_id.id
 
-        # Replace company name by company complete name in the session
-        # The values are used in the switch_company_menu widget (web module)
-        result["user_companies"]["current_company"] = user.company_id.id
+            # Assuming 'allowed_companies' is the original list of tuples
+            allowed_companies = [
+                (comp.id, comp.complete_name) for comp in user.company_ids
+            ]
 
-        # Assuming 'allowed_companies' is the original list of tuples
-        allowed_companies = [(comp.id, comp.complete_name) for comp in user.company_ids]
+            # Convert the list of tuples to a dictionary of dictionaries
+            new_allowed_companies = {
+                comp_id: {"id": comp_id, "name": comp_name, "sequence": 0}
+                for comp_id, comp_name in allowed_companies
+            }
 
-        # Convert the list of tuples to a dictionary of dictionaries
-        new_allowed_companies = {
-            comp_id: {"id": comp_id, "name": comp_name, "sequence": 0}
-            for comp_id, comp_name in allowed_companies
-        }
-
-        if display_switch_company_menu:
             result["user_companies"]["allowed_companies"] = new_allowed_companies
 
         return result

--- a/res_company_code/tests/__init__.py
+++ b/res_company_code/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_ir_http
 from . import test_res_company_code

--- a/res_company_code/tests/test_ir_http.py
+++ b/res_company_code/tests/test_ir_http.py
@@ -1,0 +1,25 @@
+import json
+from uuid import uuid4
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSessionInfo(HttpCase):
+    def test_admin_user(self):
+        self.authenticate("admin", "admin")
+        info = self._get_session_info()
+        self.assertGreater(len(info["user_companies"]["allowed_companies"]), 1)
+
+    def test_portal_user(self):
+        self.authenticate("portal", "portal")
+        info = self._get_session_info()
+        self.assertNotIn("user_companies", info)
+
+    def _get_session_info(self):
+        data = json.dumps(dict(jsonrpc="2.0", method="call", id=str(uuid4())))
+        headers = {"Content-Type": "application/json"}
+        response = self.url_open(
+            "/web/session/get_session_info", data=data, headers=headers
+        )
+        return response.json()["result"]


### PR DESCRIPTION
This adds some defensive code to avoid an error updating session_info values that have not been populated.