### PR TITLE
[14.0][IMP] product_supplierinfo_intercompany: handle active toggle

### DIFF
--- a/product_supplierinfo_intercompany/models/product_pricelist.py
+++ b/product_supplierinfo_intercompany/models/product_pricelist.py
@@ -43,3 +43,11 @@ class ProductPricelist(models.Model):
         self.sudo().with_context(automatic_intercompany_sync=True).mapped(
             "generated_supplierinfo_ids"
         ).unlink()
+
+    def toggle_active(self):
+        super().toggle_active()
+        for rec in self:
+            if rec.active:
+                rec._active_intercompany()
+            else:
+                rec._unactive_intercompany()

--- a/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
+++ b/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
@@ -149,6 +149,14 @@ class TestIntercompanySupplier(TestIntercompanySupplierCase):
         supplierinfo = self._get_supplier_info()
         self.assertEqual(len(supplierinfo), 0)
 
+    def test_unactive_pricelist_intercompany(self):
+        self.pricelist_intercompany.toggle_active()
+        supplierinfo = self._get_supplier_info()
+        self.assertEqual(len(supplierinfo), 0)
+        self.pricelist_intercompany.toggle_active()
+        supplierinfo = self._get_supplier_info()
+        self.assertEqual(len(supplierinfo), 4)
+
     def test_intercompany_access_rule(self):
         # Check that supplier this supplier info are not visible
         # with the current user "demo"


### PR DESCRIPTION
On pricelist archiving the supplierinfo line remain active at product level