### PR TITLE
[16.0][FIX] account_invoice_inter_company : clean_context not working correctly

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -135,6 +135,7 @@ class AccountMove(models.Model):
             force_number = inter_invoice.name
             inter_invoice.with_context(force_delete=True).unlink()
         # create destination invoice
+        self = self.with_context(**clean_context(self.env.context))
         dest_invoice_data = self._prepare_invoice_data(dest_company)
         if force_number:
             dest_invoice_data["name"] = force_number
@@ -214,7 +215,6 @@ class AccountMove(models.Model):
         :rtype dest_company : res.company record
         """
         self.ensure_one()
-        self = self.with_context(**clean_context(self.env.context))
         # check if the journal is define in dest company
         self._check_dest_journal(dest_company)
         vals = {

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -135,7 +135,7 @@ class AccountMove(models.Model):
             force_number = inter_invoice.name
             inter_invoice.with_context(force_delete=True).unlink()
         # create destination invoice
-        self = self.with_context(**clean_context(self.env.context))
+        self = self.with_context(clean_context(self.env.context))
         dest_invoice_data = self._prepare_invoice_data(dest_company)
         if force_number:
             dest_invoice_data["name"] = force_number

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -52,6 +52,14 @@ class TestAccountInvoiceInterCompanyBase(TransactionCase):
         cls.partner_company_b = cls.env["res.partner"].create(
             {"name": cls.company_b.name, "is_company": True}
         )
+        cls.child_partner_company_a = cls.env["res.partner"].create(
+            {
+                "name": "Child, Company A",
+                "is_company": False,
+                "company_id": False,
+                "parent_id": cls.partner_company_a.id,
+            }
+        )
         cls.child_partner_company_b = cls.env["res.partner"].create(
             {
                 "name": "Child, Company B",
@@ -554,3 +562,12 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
             [("auto_invoice_id", "=", self.invoice_company_a.id)]
         )
         self.assertFalse(invoices)
+
+    def test_no_propagation_of_partner_shipping(self):
+        self.invoice_company_a.with_context(
+            default_partner_shipping_id=self.child_partner_company_a.id
+        ).with_user(self.user_company_a.id).action_post()
+        invoice = self.account_move_obj.with_user(self.user_company_b.id).search(
+            [("auto_invoice_id", "=", self.invoice_company_a.id)]
+        )
+        self.assertEqual(invoice.partner_shipping_id, self.partner_company_a)


### PR DESCRIPTION
In some cases,  some default values appear in context (default_partner_shipping_id, ...) and are propagate in the counterpart invoice. 
As discuss here https://github.com/OCA/multi-company/issues/651 and https://github.com/OCA/multi-company/pull/652, we don't want to propagate these values between invoices. 

For example : 
When we open an invoice via the method `action_view_invoice`  from a sale or purchase order. 

Also, calling `clean_context` with ** not working, and without ** precommit fails. 

cc @pedrobaeza , @metaminux 
