### PR TITLE
[14.0][IMP] Don't set picking to done automatically

### DIFF
--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -46,6 +46,7 @@ class ResCompany(models.Model):
         string="On sync picking failure",
         default="raise",
         help="Pick action to perform on sync picking failure",
+    )
     sync_picking_state = fields.Boolean(
         string="Sync the receipt state with the delivery state",
         default=lambda p: p.sync_picking,

--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -46,6 +46,12 @@ class ResCompany(models.Model):
         string="On sync picking failure",
         default="raise",
         help="Pick action to perform on sync picking failure",
+    sync_picking_state = fields.Boolean(
+        string="Sync the receipt state with the delivery state",
+        default=lambda p: p.sync_picking,
+        help="State of receipt picking syncs with state of the delivery "
+        "from the source company. Note this disallows user to manually "
+        "correct or change a picking that did not sync properly.",
     )
     block_po_manual_picking_validation = fields.Boolean(
         string="Block manual validation of picking in the destination company",

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -49,6 +49,7 @@ class InterCompanyRulesConfig(models.TransientModel):
     )
     sync_picking_failure_action = fields.Selection(
         related="company_id.sync_picking_failure_action",
+    )
     sync_picking_state = fields.Boolean(
         related="company_id.sync_picking_state",
         readonly=False,

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -49,6 +49,8 @@ class InterCompanyRulesConfig(models.TransientModel):
     )
     sync_picking_failure_action = fields.Selection(
         related="company_id.sync_picking_failure_action",
+    sync_picking_state = fields.Boolean(
+        related="company_id.sync_picking_state",
         readonly=False,
     )
     block_po_manual_picking_validation = fields.Boolean(

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -21,7 +21,8 @@ class StockPicking(models.Model):
         res = super()._compute_state()
         for picking in self:
             if (
-                picking.intercompany_picking_id
+                picking.company_id.sync_picking_state
+                and picking.intercompany_picking_id
                 and picking.picking_type_code == "incoming"
                 and picking.state not in ["done", "cancel"]
             ):

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -326,6 +326,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
     def test_sync_picking(self):
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
 
         purchase = self._create_purchase_order(
             self.partner_company_b, self.consumable_product
@@ -378,6 +380,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         # A backorder should have been made for both
         self.assertTrue(len(sale.picking_ids) > 1)
         self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
+        # The original orders should now be done.
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertEqual(po_picking_id.state, "done")
 
     def test_sync_picking_no_backorder(self):
         self.company_a.sync_picking = True
@@ -455,6 +460,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         )
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
 
         purchase = self._create_purchase_order(
             self.partner_company_b,
@@ -529,6 +536,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         # A backorder should have been made for both
         self.assertTrue(len(sale.picking_ids) > 1)
         self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
+        # The original orders should now be done.
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertEqual(po_picking_id.state, "done")
 
     def test_sync_picking_same_product_multiple_lines(self):
         """
@@ -661,6 +671,10 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 "3.0 Units of Consumable Product 2.+instead of 8.0 Units", re.DOTALL
             ),
         )
+        print(so_picking_id.state)
+        po_picking_id = purchase.picking_ids
+        print(po_picking_id.state)
+        # Upon confirm, I expect here an issue
 
     def test_block_manual_validation(self):
         """

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -354,14 +354,16 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             so_picking_id.move_lines.product_qty,
         )
 
-        so_picking_id.state = "done"
+        # Validate sale order, create backorder
         wizard_data = so_picking_id.with_user(self.user_company_b).button_validate()
         wizard = (
             self.env["stock.backorder.confirmation"]
             .with_context(**wizard_data.get("context"))
             .create({})
         )
-        wizard.process()
+        wizard.with_user(self.user_company_b).process()
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertNotEqual((sale.picking_ids - so_picking_id).state, "done")
 
         # Quantities should have been synced
         self.assertNotEqual(po_picking_id, so_picking_id)
@@ -455,7 +457,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         self.company_b.sync_picking = True
 
         purchase = self._create_purchase_order(
-            self.partner_company_b, self.stockable_product_serial
+            self.partner_company_b,
+            self.stockable_product_serial + self.consumable_product,
         )
         sale = self._approve_po(purchase)
 
@@ -463,14 +466,15 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         po_picking_id = purchase.picking_ids
         so_picking_id = sale.picking_ids
 
-        so_move = so_picking_id.move_lines
-        so_move.move_line_ids = [
+        so_moves = so_picking_id.move_lines
+        so_moves[1].quantity_done = 2
+        so_moves[0].move_line_ids = [
             (
                 0,
                 0,
                 {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
+                    "location_id": so_moves[0].location_id.id,
+                    "location_dest_id": so_moves[0].location_dest_id.id,
                     "product_id": self.stockable_product_serial.id,
                     "product_uom_id": self.stockable_product_serial.uom_id.id,
                     "qty_done": 1,
@@ -482,21 +486,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 0,
                 0,
                 {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "qty_done": 1,
-                    "lot_id": self.serial_2.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
-            (
-                0,
-                0,
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
+                    "location_id": so_moves[0].location_id.id,
+                    "location_dest_id": so_moves[0].location_dest_id.id,
                     "product_id": self.stockable_product_serial.id,
                     "product_uom_id": self.stockable_product_serial.uom_id.id,
                     "qty_done": 1,
@@ -505,9 +496,17 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 },
             ),
         ]
-        so_picking_id.button_validate()
+        wizard_data = so_picking_id.with_user(self.user_company_b).button_validate()
+        wizard = (
+            self.env["stock.backorder.confirmation"]
+            .with_context(**wizard_data.get("context"))
+            .create({})
+        )
+        wizard.with_user(self.user_company_b).process()
+        self.assertEqual(so_picking_id.state, "done")
+        self.assertNotEqual((sale.picking_ids - so_picking_id).state, "done")
 
-        so_lots = so_move.mapped("move_line_ids.lot_id")
+        so_lots = so_moves.mapped("move_line_ids.lot_id")
         po_lots = po_picking_id.mapped("move_lines.move_line_ids.lot_id")
         self.assertEqual(
             len(so_lots),
@@ -518,8 +517,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             so_lots, po_lots, msg="The lots of the moves should be different objects"
         )
         self.assertEqual(
-            so_lots.mapped("name"),
-            po_lots.mapped("name"),
+            so_lots.sudo().mapped("name"),
+            po_lots.sudo().mapped("name"),
             msg="The lots should have the same name in both moves",
         )
         self.assertIn(
@@ -527,6 +526,9 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             po_lots,
             msg="Serial 333 already existed, a new one shouldn't have been created",
         )
+        # A backorder should have been made for both
+        self.assertTrue(len(sale.picking_ids) > 1)
+        self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
 
     def test_sync_picking_same_product_multiple_lines(self):
         """

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -387,6 +387,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
     def test_sync_picking_no_backorder(self):
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
 
         purchase = self._create_purchase_order(
             self.partner_company_b, self.consumable_product
@@ -683,6 +685,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         """
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True
+        self.company_a.sync_picking_state = True
+        self.company_b.sync_picking_state = True
         self.company_a.block_po_manual_picking_validation = True
         self.company_b.block_po_manual_picking_validation = True
         purchase = self._create_purchase_order(

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -62,6 +62,12 @@
                         attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')], 'required': [('sync_picking_failure_action', '=', 'notify')]}"
                         class="oe_inline"
                     />
+                    <field name="sync_picking_state" class="oe_inline" />
+                    <label
+                        string="Sync picking state"
+                        class="o_light_label"
+                        for="sync_picking_state"
+                    />
                     <br />
                     <field
                         name="block_po_manual_picking_validation"


### PR DESCRIPTION
Currently the code forces PO picking state to Done when SO picking is done, but this can be harmful:

If there was a mismatch in SO and PO move lines, activity is created for user to fix, but picking is already set to Done, then user can't correct anything

Revival of https://github.com/OCA/multi-company/pull/642