### PR TITLE
[14.0][UPD] purchase_sale_inter_company: notify user

### DIFF
--- a/purchase_sale_inter_company/models/res_company.py
+++ b/purchase_sale_inter_company/models/res_company.py
@@ -51,3 +51,8 @@ class ResCompany(models.Model):
         string="Block manual validation of picking in the destination company",
     )
     notify_user_id = fields.Many2one("res.users", "User to Notify")
+    notification_side = fields.Selection(
+        [("so", "Sale Order Source Company"), ("po", "Purchase Destination Company")],
+        default="so",
+        help="Select which Company side to notify",
+    )

--- a/purchase_sale_inter_company/models/res_config.py
+++ b/purchase_sale_inter_company/models/res_config.py
@@ -61,3 +61,6 @@ class InterCompanyRulesConfig(models.TransientModel):
         help="User to notify incase of sync picking failure.",
         readonly=False,
     )
+    notification_side = fields.Selection(
+        related="company_id.notification_side", string="Notify", readonly=False
+    )

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -115,13 +115,13 @@ class StockPicking(models.Model):
 
     def _get_user_to_notify(self, purchase):
         """Notify user based on res.config.settings"""
-        if self.company_id.notification_side == "so":
+        if purchase.company_id.notification_side == "so":
             return (
                 self.company_id.notify_user_id.id
                 or self.sale_id.user_id.id
                 or self.sale_id.team_id.user_id.id
             )
-        return purchase.user_id.id
+        return purchase.company_id.notify_user_id.id or purchase.user_id.id
 
     def button_validate(self):
         res = super().button_validate()

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -90,11 +90,11 @@ class StockPicking(models.Model):
                         dest_lot_id = lot_id.copy({"company_id": po_ml.company_id.id})
                     po_ml.lot_id = dest_lot_id
 
-        except Exception:
+        except Exception as e:
             if self.env.company.sync_picking_failure_action == "raise":
                 raise
             else:
-                self._notify_picking_problem(purchase)
+                self._notify_picking_problem(purchase, additional_note=str(e))
 
     def _notify_picking_problem(self, purchase, additional_note=False):
         self.ensure_one()

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -723,6 +723,43 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             warning_activity.user_id, so_picking_id.company_id.notify_user_id
         )
 
+    def test_notify_picking_problem_dest_company(self):
+        self.company_a.sync_picking = True
+        self.company_b.sync_picking = True
+        self.company_a.sync_picking_failure_action = "notify"
+        self.company_b.sync_picking_failure_action = "notify"
+        self.company_a.notification_side = "po"
+        self.company_b.notification_side = "po"
+        purchase = self._create_purchase_order(
+            self.partner_company_b, self.consumable_product
+        )
+        purchase_2 = self._create_purchase_order(
+            self.partner_company_b, self.consumable_product
+        )
+        purchase.order_line += purchase.order_line.copy({"product_qty": 2})
+        sale = self._approve_po(purchase)
+        sale.action_confirm()
+
+        # validate the SO picking
+        so_picking_id = sale.picking_ids
+        # Set as purchase_2 user user_company_a
+        purchase_2.user_id = self.user_company_a
+        # Link to a new purchase order so it can trigger
+        # `PO does not exist or has no receipts` in _sync_receipt_with_delivery
+        sale.auto_purchase_order_id = purchase_2
+
+        # Set quantities done on the picking and validate
+        for move in so_picking_id.move_lines:
+            move.quantity_done = move.product_uom_qty
+        so_picking_id.button_validate()
+
+        activity_warning = self.env.ref("mail.mail_activity_data_warning")
+        warning_activity = so_picking_id.activity_ids.filtered(
+            lambda a: a.activity_type_id == activity_warning
+        )
+        # Test the user assigned to the activity
+        self.assertEqual(warning_activity.user_id, self.user_company_a)
+
     def test_raise_picking_problem(self):
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -53,13 +53,25 @@
                     />
                     <br />
                     <label
+                        for="notification_side"
+                        class="o_light_label"
+                        attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')]}"
+                    />
+                    <field
+                        name="notification_side"
+                        widget="radio"
+                        attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')], 'required': [('sync_picking_failure_action', '=', 'notify')]}"
+                        class="oe_inline"
+                    />
+                    <br />
+                    <label
                         for="notify_user_id"
                         class="o_light_label"
                         attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')]}"
                     />
                     <field
                         name="notify_user_id"
-                        attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')], 'required': [('sync_picking_failure_action', '=', 'notify')]}"
+                        attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')], 'required': [('sync_picking_failure_action', '=', 'notify'), ('notification_side', '=', 'so')]}"
                         class="oe_inline"
                     />
                     <br />

--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -71,7 +71,7 @@
                     />
                     <field
                         name="notify_user_id"
-                        attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')], 'required': [('sync_picking_failure_action', '=', 'notify'), ('notification_side', '=', 'so')]}"
+                        attrs="{'invisible': [('sync_picking_failure_action', '!=', 'notify')], 'required': [('sync_picking_failure_action', '=', 'notify')]}"
                         class="oe_inline"
                     />
                     <br />


### PR DESCRIPTION
When something goes wrong during an intercompany transaction, a `mail.activity` is created for some user. With this PR, the company and the user that should be notified can be configured through `res.config.settings`.