### PR TITLE
[14.0][FIX] product_supplierinfo_intercompany: Add company to synchronise r…

### DIFF
--- a/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
+++ b/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
@@ -38,8 +38,10 @@ class ProductIntercompanySupplierMixin(models.AbstractModel):
                 )
             # We pass the pricelist in the context in order to get the right
             # sale price on record.price (compatible v8 to v12)
-            for record in self.sudo().with_context(
-                pricelist=pricelist.id, automatic_intercompany_sync=True
+            for record in (
+                self.sudo()
+                .with_context(pricelist=pricelist.id, automatic_intercompany_sync=True)
+                .with_company(pricelist.company_id)
             ):
                 domain = record._get_intercompany_supplier_info_domain(pricelist)
                 supplierinfo = record.env["product.supplierinfo"].search(domain)


### PR DESCRIPTION
…ecord context

Due to the following lines:
https://github.com/OCA/multi-company/blob/b13c5448321b40875ac6320260ba0e432bb58c82/product_supplierinfo_intercompany/models/product_template.py#L67-L71

All intercompany `supplierinfo` records are updated whenever any change is made to the product. This creates an issue in the following scenario:

1. Create Product A with no `company_id` (shared across companies).
2. Create a pricelist for the Chicago company with the intercompany option enabled and an item based on a formula using cost.
3. Modify the product cost from the Chicago company `supplierinfo` is computed correctly.
4. **However,** if you modify the product cost from the San Francisco company, it also updates `supplierinfo`, but now using San Francisco's cost.

Adding the company from the pricelist helps avoid this issue.
