### PR TITLE
[15.0][FIX] product_multi_company: search in False

### DIFF
--- a/product_multi_company/models/__init__.py
+++ b/product_multi_company/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import product_template
 from . import product_category
+from . import product_product

--- a/product_multi_company/models/product_product.py
+++ b/product_multi_company/models/product_product.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Tecnativa - David Vidal
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        dom = self.env["multi.company.abstract"]._patch_company_domain(args)
+        return super().search(dom, offset=offset, limit=limit, order=order, count=count)

--- a/product_multi_company/static/description/index.html
+++ b/product_multi_company/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -429,7 +429,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -60,6 +60,29 @@ class TestProductMultiCompany(ProductMultiCompanyCommon, common.TransactionCase)
                 self.user_company_2
             ).description_sale = "Test 3"
 
+    def test_search_product(self):
+        """Products with no company are shared across companies but we need to convert
+        those queries with an or operator"""
+        expected_products = (
+            self.product_company_both
+            + self.product_company_1
+            + self.product_company_none
+        )
+        searched_templates = self.env["product.template"].search(
+            [
+                ("company_id", "in", [self.company_1.id, False]),
+                ("id", "in", expected_products.product_tmpl_id.ids),
+            ]
+        )
+        self.assertEqual(searched_templates, expected_products.product_tmpl_id)
+        searched_products = self.product_obj.search(
+            [
+                ("company_id", "in", [self.company_1.id, False]),
+                ("id", "in", expected_products.ids),
+            ]
+        )
+        self.assertEqual(searched_products, expected_products)
+
     def test_uninstall(self):
         from ..hooks import uninstall_hook
 


### PR DESCRIPTION
product.product has a delageted inheritance from product.template so we are getting the fields logic but not the ORM logic. We need some of that logic in the search method to be able to get the right results with domains like [("company_id", "in", [1, False]) to include records which are shared between companies.

cc @Tecnativa TT51779

please review @pedrobaeza @carlosdauden 