### PR TITLE
[16.0][FIX] base_multi_company: search with in operator

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -87,7 +87,7 @@ class MultiCompanyAbstract(models.AbstractModel):
         if args is None:
             args = []
         for arg in args:
-            if type(arg) == list and arg[:2] == ["company_id", "in"]:
+            if type(arg) in {list, tuple} and list(arg[:2]) == ["company_id", "in"]:
                 fix = []
                 for _i in range(len(arg[2]) - 1):
                     fix.append("|")
@@ -115,3 +115,10 @@ class MultiCompanyAbstract(models.AbstractModel):
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
         new_domain = self._patch_company_domain(domain)
         return super().search_read(new_domain, fields, offset, limit, order)
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        args = self._patch_company_domain(args)
+        return super().search(
+            args, offset=offset, limit=limit, order=order, count=count
+        )

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -111,6 +111,13 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         )
         self.assertEqual([{"id": self.record_1.id, "name": self.record_1.name}], result)
 
+    def test_search_in_false_company(self):
+        """Records with no company are shared across companies but we need to convert
+        those queries with an or operator"""
+        self.record_1.company_ids = False
+        result = self.test_model.search([("company_id", "in", [1, False])])
+        self.assertEqual(result, self.record_1)
+
     def test_patch_company_domain(self):
         new_domain = self.test_model._patch_company_domain(
             [["company_id", "in", [False, self.company_2.id]]]

--- a/purchase_sale_container_deposit_inter_company/tests/test_inter_company_purchase_sale_container_deposit.py
+++ b/purchase_sale_container_deposit_inter_company/tests/test_inter_company_purchase_sale_container_deposit.py
@@ -115,7 +115,7 @@ class TestProductPackagingContainerDepositMixin(
         # With the "update_order_container_deposit_quantity" context
         # We can update order container deposit quantity on PO and locked SO also
         purchase.with_context(
-            skip_update_container_deposit=False
+            skip_update_container_deposit=False, allow_update_locked_sales=True
         ).update_order_container_deposit_quantity()
         # PO product packaging container deposit quantities
         po_pallet_line = purchase.order_line.filtered(


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/multi-company/pull/715

When searching the company with a domain like [("company_id", "in", [1, False]) to include records which are shared between companies we won't get those with no companies at all. That will lead to logical errors in several workflows.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT51779