### PR TITLE
[16.0][IMP] purchase_sale_inter_company : delivery date propagation

### DIFF
--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -22,3 +22,10 @@ class SaleOrder(models.Model):
                 if line.auto_purchase_line_id:
                     line.auto_purchase_line_id.price_unit = line.price_unit
         return super().action_confirm()
+
+    def write(self, vals):
+        res = super().write(vals)
+        purchase_id = self.auto_purchase_order_id
+        if "commitment_date" in vals and purchase_id:
+            purchase_id.sudo().write({"date_planned": vals["commitment_date"]})
+        return res

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -275,3 +275,11 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             purchase.order_line[0].with_context(allow_update_locked_sales=True).write(
                 {"product_qty": 99}
             )
+
+    def test_change_delivery_date_sale(self):
+        from dateutil.relativedelta import relativedelta
+
+        sale = self._approve_po()
+        self.assertEqual(self.purchase_company_a.date_planned, sale.commitment_date)
+        sale.commitment_date = sale.commitment_date + relativedelta(days=3)
+        self.assertEqual(self.purchase_company_a.date_planned, sale.commitment_date)


### PR DESCRIPTION
Inspired of https://github.com/OCA/multi-company/pull/669

Propagate the commitment date from sale to purchase in the buyer company