### PR TITLE
[17.0][FIX] base_multi_company: search with in operator

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -86,7 +86,10 @@ class MultiCompanyAbstract(models.AbstractModel):
         if args is None:
             args = []
         for arg in args:
-            if isinstance(arg, list) and arg[:2] == ["company_id", "in"]:
+            if (isinstance(arg, list) or isinstance(arg, tuple)) and list(arg[:2]) == [
+                "company_id",
+                "in",
+            ]:
                 fix = []
                 for _i in range(len(arg[2]) - 1):
                     fix.append("|")
@@ -109,6 +112,15 @@ class MultiCompanyAbstract(models.AbstractModel):
         )
 
     @api.model
-    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+    def search_read(
+        self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs
+    ):
         new_domain = self._patch_company_domain(domain)
-        return super().search_read(new_domain, fields, offset, limit, order)
+        return super().search_read(
+            new_domain, fields, offset, limit, order, **read_kwargs
+        )
+
+    @api.model
+    def search(self, domain, offset=0, limit=None, order=None):
+        domain = self._patch_company_domain(domain)
+        return super().search(domain, offset=offset, limit=limit, order=order)

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -111,6 +111,13 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         )
         self.assertEqual([{"id": self.record_1.id, "name": self.record_1.name}], result)
 
+    def test_search_in_false_company(self):
+        """Records with no company are shared across companies but we need to convert
+        those queries with an or operator"""
+        self.record_1.company_ids = False
+        result = self.test_model.search([("company_id", "in", [1, False])])
+        self.assertEqual(result, self.record_1)
+
     def test_patch_company_domain(self):
         new_domain = self.test_model._patch_company_domain(
             [["company_id", "in", [False, self.company_2.id]]]


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/multi-company/pull/717

When searching the company with a domain like [("company_id", "in", [1, False]) to include records which are shared between companies we won't get those with no companies at all. That will lead to logical errors in several workflows.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT51779