### PR TITLE
[FIX] stock_intercompany_bidirectional: Fix incorrect move warehouse

### DIFF
--- a/stock_intercompany_bidirectional/__manifest__.py
+++ b/stock_intercompany_bidirectional/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Stock Intercompany Bidirectional",
     "summary": "Bidirectional operations for the Stock Intercomany module",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Inventory/Inventory",
     "website": "https://github.com/OCA/multi-company",
     "author": "Cetmix, Odoo Community Association (OCA)",


### PR DESCRIPTION
Before this commit
==============

After moving from company A to company B, a route with a push rule for company B does not work because the stock move retains the warehouse reference from company A

After this commit
=============

Triggers push rule and creates a picking between locations in company B, the link to the warehouse for the stock move is updated

