### PR TITLE
[FIX] storing display_name breaks contact widget in v17 as from v17 o…

### DIFF
--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -10,15 +10,6 @@ class ResPartner(models.Model):
     _inherit = ["multi.company.abstract", "res.partner"]
     _name = "res.partner"
 
-    # This is needed because after installation this field becomes
-    # unsearchable and unsortable. Which is not explicitly changed in this
-    # module and as such can be considered an undesired yield.
-    display_name = fields.Char(
-        compute="_compute_display_name",
-        store=True,
-        index=True,
-    )
-
     @api.model_create_multi
     def create(self, vals_list):
         """Neutralize the default value applied to company_id that can't be

--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2019 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html.html
 
-from odoo import Command, _, api, fields, models
+from odoo import Command, _, api, models
 from odoo.exceptions import ValidationError
 
 


### PR DESCRIPTION
storing display_name breaks contact widget in v17 as from v17 onward the field is no longer stored in the base and replaced by complete_name

fixes issue #734 