### PR TITLE
[16.0][IMP] product_category_company: allow the company to be false in search domain

### DIFF
--- a/product_category_company/models/product_category.py
+++ b/product_category_company/models/product_category.py
@@ -20,5 +20,5 @@ class ProductCategory(models.Model):
     @api.model
     def _search(self, domain, *args, **kwargs):
         if "company_id" not in (item[0] for item in domain):
-            domain += [("company_id", "in", self.env.user.company_ids.ids)]
+            domain += [("company_id", "in", [False] + self.env.user.company_ids.ids)]
         return super()._search(domain, *args, **kwargs)


### PR DESCRIPTION
This PR modifies the search method so that categories without company set are also returned. This is needed because without this change, product categories without company were not appearing in the product category list neither by searching.