### PR TITLE
[16.0][FIX] stock_intercompany: Multi-company access

### DIFF
--- a/stock_intercompany/models/stock_picking.py
+++ b/stock_intercompany/models/stock_picking.py
@@ -62,7 +62,7 @@ class StockPicking(models.Model):
                     dict(common_vals, counterpart_of_move_id=sm.id)
                 )[0],
             )
-            for sm in self.move_ids
+            for sm in self.move_ids.sudo()
         ]
         move_line_ids = [
             (
@@ -72,7 +72,7 @@ class StockPicking(models.Model):
                     dict(common_vals, move_id=False, counterpart_of_line_id=ln.id)
                 )[0],
             )
-            for ln in self.move_line_ids
+            for ln in self.move_line_ids.sudo()
         ]
         return move_ids, move_line_ids
 


### PR DESCRIPTION
Before this commit:
==============

In cases when move lines contain some company dependent data and the current user does not have access to the company, an access error occurs.

After this commit
=============

This hotfix allows you to copy stock move data to bypass company restrictions

Task: 4192