### PR TITLE
[16.0][FIX] base_multi_company: support `in False` search operators

### DIFF
--- a/base_multi_company/README.rst
+++ b/base_multi_company/README.rst
@@ -84,6 +84,7 @@ Contributors
 * Rodrigo Ferreira <rodrigosferreira91@gmail.com>
 * Florian da Costa <florian.dacosta@akretion.com>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_multi_company/hooks.py
+++ b/base_multi_company/hooks.py
@@ -1,6 +1,8 @@
 # Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2017 LasLabs Inc.
 # License LGPL-3 - See http://www.gnu.org/licenses/lgpl-3.0.html
+import warnings
+
 from odoo import SUPERUSER_ID, api
 
 __all__ = [
@@ -15,6 +17,10 @@ def set_security_rule(env, rule_ref):
     :param: env: Environment
     :param: rule_ref: XML-ID of the security rule to change.
     """
+    warnings.warn(
+        "This hook is deprecated. Use `fill_company_ids` instead.",
+        DeprecationWarning,
+    )
     rule = env.ref(rule_ref)
     if not rule:  # safeguard if it's deleted
         return
@@ -38,6 +44,12 @@ def post_init_hook(cr, rule_ref, model_name):
     """
     env = api.Environment(cr, SUPERUSER_ID, {})
     set_security_rule(env, rule_ref)
+    fill_company_ids(cr, model_name)
+
+
+def fill_company_ids(cr, model_name):
+    """Fill company_ids with company_id values."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
     # Copy company values
     model = env[model_name]
     table_name = model._fields["company_ids"].relation
@@ -65,6 +77,7 @@ def uninstall_hook(cr, rule_ref):
         rule_ref (string): XML ID of security rule to remove the
             `domain_force` from.
     """
+    warnings.warn("This hook is deprecated.", DeprecationWarning)
     env = api.Environment(cr, SUPERUSER_ID, {})
     # Change access rule
     rule = env.ref(rule_ref)

--- a/base_multi_company/readme/CONTRIBUTORS.rst
+++ b/base_multi_company/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Rodrigo Ferreira <rodrigosferreira91@gmail.com>
 * Florian da Costa <florian.dacosta@akretion.com>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)

--- a/base_multi_company/readme/DEVELOPER.rst
+++ b/base_multi_company/readme/DEVELOPER.rst
@@ -4,13 +4,13 @@ Implementation
 Multi Company Abstract
 ----------------------
 
-The `multi.company.abstract` model is meant to be inherited by any model that
+The ``multi.company.abstract`` model is meant to be inherited by any model that
 wants to implement multi-company functionality. The logic does not require a
 pre-existing company field on the inheriting model, but will not be affected
 if one does exist.
 
-When inheriting the `multi.company.abstract` model, you must take care that
-it is the first model listed in the `_inherit` array
+When inheriting the ``multi.company.abstract`` model, you must take care that
+it is the first model listed in the ``_inherit`` array
 
 .. code-block:: python
 
@@ -19,53 +19,35 @@ it is the first model listed in the `_inherit` array
        _name = "product.template"
        _description = "Product Template (Multi-Company)"
 
-The following fields are provided by `multi.company.abstract`:
+The following fields are provided by ``multi.company.abstract``:
 
-* `company_ids` - All of the companies that this record belongs to. This is a
-  special `res.company.assignment` view, which allows for the circumvention of
+* ``company_ids`` - All of the companies that this record belongs to. This is a
+  special ``res.company.assignment`` view, which allows for the circumvention of
   standard cross-company security policies. These policies would normally
   restrict a user from seeing another company unless it is currently operating
   under that company. Be aware of apples to oranges issues when comparing the
   records from this field against actual company records.
-* `company_id` - Passes through a singleton company based on the current user,
+* ``company_id`` - Passes through a singleton company based on the current user,
   and the allowed companies for the record.
-* `no_company_ids` - As there is a limitation in Odoo ORM to get real False values
-  in Many2many fields (solved on 2022-03-23 https://github.com/odoo/odoo/pull/81344).
 
 Hooks
 -----
 
-A generic `post_init_hook` and `uninstall_hook` is provided, which will alter
-a pre-existing single-company security rule to be multi-company aware.
+A generic ``fill_company_ids`` hook is provided, to be used in submodules'
+``post_init_hook``, which will convert the ``company_id`` field to a
+``company_ids`` field, respecting previous company assignments.
 
-These hooks will unfortunately not work in every circumstance, but they cut out
+It will unfortunately not work in every circumstance, but it cuts out
 significant boilerplate when relevant.
 
 .. code-block:: python
 
-   import logging
-
-   _logger = logging.getLogger(__name__)
-
-   try:
-       from odoo.addons.base_multi_company import hooks
-   except ImportError:
-       _logger.info('Cannot find `base_multi_company` module in addons path.')
-
+   from odoo.addons.base_multi_company import hooks
 
    def post_init_hook(cr, registry):
-       hooks.post_init_hook(
+       hooks.fill_company_ids(
            cr,
-           'product.product_comp_rule',
            'product.template',
        )
 
-
-   def uninstall_hook(cr, registry):
-       hooks.uninstall_hook(
-           cr,
-           'product.product_comp_rule',
-       )
-
-A module implementing these hooks would need to first identify the proper rule
-for the record (`product.product_comp_rule` in the above example).
+Other hooks are deprecated and no longer needed.

--- a/base_multi_company/static/description/index.html
+++ b/base_multi_company/static/description/index.html
@@ -427,6 +427,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Rodrigo Ferreira &lt;<a class="reference external" href="mailto:rodrigosferreira91&#64;gmail.com">rodrigosferreira91&#64;gmail.com</a>&gt;</li>
 <li>Florian da Costa &lt;<a class="reference external" href="mailto:florian.dacosta&#64;akretion.com">florian.dacosta&#64;akretion.com</a>&gt;</li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
+<li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Before this commit, when doing a read with a domain such as [the one used by upstream `base.res_partner_rule`][1], the read failed to find records without company.

This is now fixed in the base module, adding tested support for such operators. The only relevant part of the hooks that were provided to workaround the issue is extracted to a new `post_init_hook`. All other hooks are marked as deprecated.

**Instructions for functional tests:** This refactor is internal and should not be noticed functionally. The modules `product_multi_company` and `partner_multi_company` should work just as always. If so, then this is good.

[1]: https://github.com/odoo/odoo/blob/db072461cddced2a8f65a64fb6d2ddf0dd79b38e/odoo/addons/base/security/base_security.xml#L23

@moduon MT-8863 MT-8873