### PR TITLE
[16.0][FIX] partner_multi_company: remove unnecessary rule rewrite hooks

### DIFF
--- a/partner_multi_company/__init__.py
+++ b/partner_multi_company/__init__.py
@@ -1,3 +1,2 @@
 from . import models
 from .hooks import post_init_hook
-from .hooks import uninstall_hook

--- a/partner_multi_company/__manifest__.py
+++ b/partner_multi_company/__manifest__.py
@@ -14,5 +14,4 @@
     "data": ["views/res_partner_view.xml"],
     "installable": True,
     "post_init_hook": "post_init_hook",
-    "uninstall_hook": "uninstall_hook",
 }

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -1,36 +1,11 @@
-import logging
-
 from odoo import SUPERUSER_ID, api
 
-_logger = logging.getLogger(__name__)
+from odoo.addons.base_multi_company import hooks
 
 
 def post_init_hook(cr, registry):
-    """
-    Set access rule to support multi-company fields
-    """
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    # Change access rule
-    rule = env.ref("base.res_partner_rule")
-    rule.write(
-        {
-            "domain_force": (
-                "['|', '|', ('partner_share', '=', False),"
-                "('company_ids', 'in', company_ids),"
-                "('company_ids', '=', False)]"
-            ),
-        }
-    )
-    # Initialize m2m table for preserving old restrictions
-    cr.execute(
-        """
-        INSERT INTO res_company_res_partner_rel
-        (res_partner_id, res_company_id)
-        SELECT id, company_id
-        FROM res_partner
-        WHERE company_id IS NOT NULL
-        """
-    )
+    """Keep multi-company behavior for partners."""
+    hooks.fill_company_ids(cr, "res.partner")
     fix_user_partner_companies(cr)
 
 
@@ -44,25 +19,3 @@ def fix_user_partner_companies(cr):
             user.partner_id.write(
                 {"company_ids": [(4, company_id) for company_id in missing_company_ids]}
             )
-
-
-def uninstall_hook(cr, registry):
-    """Restore product rule to base value.
-
-    Args:
-        cr (Cursor): Database cursor to use for operation.
-        rule_ref (string): XML ID of security rule to remove the
-            `domain_force` from.
-    """
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    # Change access rule
-    rule = env.ref("base.res_partner_rule")
-    rule.write(
-        {
-            "domain_force": (
-                "['|', '|', ('partner_share', '=', False),"
-                "('company_id', 'in', company_ids),"
-                "('company_id', '=', False)]"
-            ),
-        }
-    )

--- a/partner_multi_company/migrations/16.0.1.1.1/post-migration.py
+++ b/partner_multi_company/migrations/16.0.1.1.1/post-migration.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+from logging import getLogger
+
+from openupgradelib import openupgrade
+
+from odoo.tools import safe_eval
+
+_logger = getLogger(__name__)
+
+PREVIOUS_DOMAIN = [
+    "|",
+    "|",
+    ("partner_share", "=", False),
+    ("company_ids", "in", "COMPANY_IDS"),
+    ("company_ids", "=", False),
+]
+UPSTREAM_DOMAIN = (
+    "['|', ('partner_share', '=', False), ('company_id', 'in', company_ids + [False])]"
+)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Restore upstream partner rule."""
+    rule = env.ref("base.res_partner_rule", False)
+    if not rule:
+        return
+    try:
+        domain = safe_eval(
+            rule.domain_force, locals_dict={"company_ids": "COMPANY_IDS"}
+        )
+    except Exception:
+        _logger.warning("Unable to evaluate domain_force")
+        return
+    if domain == PREVIOUS_DOMAIN:
+        rule.domain_force = UPSTREAM_DOMAIN
+        _logger.info("Restored upstream partner rule")

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -127,18 +127,6 @@ class TestPartnerMultiCompany(common.TransactionCase):
         with self.assertRaises(AccessError):
             self.partner_company_1.with_user(self.user_company_2).name = "Test"
 
-    def test_uninstall(self):
-        from ..hooks import uninstall_hook
-
-        uninstall_hook(self.env.cr, None)
-        rule = self.env.ref("base.res_partner_rule")
-        domain = (
-            "['|', '|', ('partner_share', '=', False),"
-            "('company_id', 'in', company_ids),"
-            "('company_id', '=', False)]"
-        )
-        self.assertEqual(rule.domain_force, domain)
-
     def test_switch_user_company(self):
         self.user_company_1.company_ids = (self.company_1 + self.company_2).ids
         self.user_company_1.company_id = self.company_2.id
@@ -171,3 +159,10 @@ class TestPartnerMultiCompany(common.TransactionCase):
         user_partner.write({"company_id": False, "company_ids": [(5, False)]})
         self.user_company_1.write({"company_id": self.company_2.id})
         self.assertEqual(user_partner.company_ids.ids, [])
+
+    def test_can_read_partner_without_company(self):
+        self.assertFalse(self.partner_company_none.company_id)
+        self.assertEqual(
+            self.partner_company_none.with_user(self.user_company_1).read(["name"]),
+            [{"id": self.partner_company_none.id, "name": "partner without company"}],
+        )


### PR DESCRIPTION
Now that `base_multi_company` supports `('company_id', 'in', some_ids + [False])` domains since https://github.com/OCA/multi-company/pull/760, it's time to remove the (un)install hooks that changed those rules.

The fix is important when migrating a database from previous versions where these hooks didn't exist. In those cases, users wouldn't be able to browse some partners, getting a weird `AccessError`.

FWIW, [upstream rules changed for performance][2], so the uninstall hook had to be changed nevertheless.

[2]: https://github.com/odoo/odoo/commit/a04df5cb1411a14752ba7a4d6b3c4b7b4f1d6d44#diff-1f2cafa0e26df218210181c72e599c279fd093c4215d1dc1da5ef8875195e6c2L23-R23

Draft until:
- [x] https://github.com/OCA/multi-company/pull/760

**Instructions for functional tests:** This refactor is internal and should not be noticed functionally. The module `partner_multi_company` should work just as always. If so, then this is good.

@moduon MT-8863