### PR TITLE
[FIX] ir_config_parameter_multi_company: hook to avoid error with CRM

### DIFF
--- a/ir_config_parameter_multi_company/__init__.py
+++ b/ir_config_parameter_multi_company/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/ir_config_parameter_multi_company/__manifest__.py
+++ b/ir_config_parameter_multi_company/__manifest__.py
@@ -11,4 +11,5 @@
     "data": ["views/ir_config_parameter_view.xml", "security/parameter_security.xml"],
     "images": [],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/ir_config_parameter_multi_company/hooks.py
+++ b/ir_config_parameter_multi_company/hooks.py
@@ -1,0 +1,15 @@
+# # Copyright 2019 ACSONE SA/NV
+# # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    _logger.info("Pre-creating column company_id for table ir_config_parameter")
+    cr.execute(
+        """
+        ALTER TABLE ir_config_parameter
+        ADD COLUMN IF NOT EXISTS company_id INTEGER;
+        """
+    )


### PR DESCRIPTION
When installing the ir_config_parameter_multi_company module, an error occurs if the crm module is already installed. The issue arises because the module tries to access the company_id column in the ir_config_parameter table, but this column does not exist. Error observed: 

![Captura desde 2025-01-30 10-14-26](https://github.com/user-attachments/assets/1ba7c454-3ea4-4eba-bb1c-665e5843a492)

To solve it, a hook is added to the ir_config_parameter_multi_company module to ensure that the company_id column exists before any code attempts to use it.
