### PR TITLE
[12.0][IMP] mail_multicompany: take company using linked user

### DIFF
--- a/mail_multicompany/models/mail_message.py
+++ b/mail_multicompany/models/mail_message.py
@@ -11,11 +11,23 @@ class MailMessage(models.Model):
 
     @api.model_create_multi
     def create(self, values_list):
+        context = self.env.context
         for vals in values_list:
+            # When using mail.message.composer model and res_id are not defined but
+            # they are in the context.
+            if not vals.get("model") and context.get("active_model"):
+                vals["model"] = context.get("active_model")
+            if not vals.get("res_id") and context.get("active_id"):
+                vals["res_id"] = context.get("active_id")
             if vals.get("model") and vals.get("res_id"):
                 current_object = self.env[vals["model"]].browse(vals["res_id"])
                 if hasattr(current_object, "company_id") and current_object.company_id:
                     vals["company_id"] = current_object.company_id.id
+                # when the object has no company, we try with the user,
+                # e.g. portal.wizard.user
+                elif (hasattr(current_object, "user_id") and
+                      current_object.user_id.company_id):
+                    vals["company_id"] = current_object.user_id.company_id.id
             if not vals.get("company_id"):
                 vals["company_id"] = self.env.user.company_id.id
             # Search SMTP server with company_id or shared SMTP server
@@ -31,4 +43,4 @@ class MailMessage(models.Model):
                     )
                     .id
                 )
-        return super(MailMessage, self).create(vals)
+        return super(MailMessage, self).create(values_list)


### PR DESCRIPTION
When a contact is granted access to the portal, the user is created using OdooBot, so the emal takes the company from it even if the user is in other company.

With this change, this case is fixed.