### PR TITLE
[16.0][FIX] account_invoice_inter_company: Adjust settings view to compatibilize with remove_odoo_enterprise

### DIFF
--- a/account_invoice_inter_company/views/res_config_settings_view.xml
+++ b/account_invoice_inter_company/views/res_config_settings_view.xml
@@ -5,34 +5,37 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@id='inter_company']" position="attributes">
-                <attribute name="title" />
+                <attribute name="invisible">True</attribute>
             </xpath>
-            <xpath expr="//div[@id='inter_company']/div[2]/span" position="before">
-                <div class="o_form_label">Inter Company OCA features
-                    <span
-                        class="fa fa-lg fa-building-o"
-                        title="Values set here are company-specific."
-                        aria-label="Values set here are company-specific."
-                        groups="base.group_multi_company"
-                        role="img"
-                    />
-                </div>
-            </xpath>
-            <xpath expr="//div[@id='inter_company']/div[2]" position="inside">
-                <div id="company_share_product">
-                    <field name="company_share_product" class="oe_inline" />
-                    <label
-                        string="Common Product Catalog"
-                        class="o_light_label"
-                        for="company_share_product"
-                    />
-                </div>
-            </xpath>
-            <xpath expr="//div[@id='inter_company']" position="after">
-                <div class="col-12 col-lg-6 o_setting_box">
-                    <div class="o_setting_left_pane" />
+            <xpath expr="//div[@id='companies_setting']" position="after">
+                <div
+                    id="inter_company_oca"
+                    class="col-12 col-lg-6 o_setting_box"
+                    groups="base.group_multi_company"
+                >
+                    <field name="company_id" invisible="1" />
+                    <div class="o_setting_left_pane">
+                    </div>
                     <div class="o_setting_right_pane">
-                        <div class="o_form_label mt8">Invoicing</div>
+                        <div class="o_form_label">Inter Company OCA features
+                            <span
+                                class="fa fa-lg fa-building-o"
+                                title="Values set here are company-specific."
+                                aria-label="Values set here are company-specific."
+                                role="img"
+                            />
+                        </div>
+                        <div class="text-muted">
+                            Automatically generate counterpart documents for orders/invoices between companies
+                        </div>
+                        <div
+                            class="content-group"
+                            attrs="{'invisible': [('module_account_inter_company_rules','=',False)]}"
+                            id="inter_companies_rules"
+                        >
+                            <div class="mt16 text-warning"><strong
+                                >Save</strong> this page and come back here to set up the feature.</div>
+                        </div>
                         <div id="intercompany_invoicing">
                             <field name="intercompany_invoicing" class="oe_inline" />
                             <label
@@ -66,26 +69,19 @@
                                 for="invoice_auto_validation"
                             />
                         </div>
+                        <div
+                            id="company_share_product"
+                            attrs="{'invisible': [('intercompany_invoicing','=',False)]}"
+                        >
+                            <field name="company_share_product" class="oe_inline" />
+                            <label
+                                string="Common Product Catalog"
+                                class="o_light_label"
+                                for="company_share_product"
+                            />
+                        </div>
                     </div>
                 </div>
-            </xpath>
-            <xpath
-                expr="//div[@id='inter_company']//field[@name='module_account_inter_company_rules']"
-                position="attributes"
-            >
-                <attribute name="attrs">{'invisible': True}</attribute>
-            </xpath>
-            <xpath
-                expr="//div[@id='inter_company']//label[@for='module_account_inter_company_rules']"
-                position="attributes"
-            >
-                <attribute name="attrs">{'invisible': True}</attribute>
-            </xpath>
-            <xpath
-                expr="//div[@id='inter_company']//field[@name='module_account_inter_company_rules']/../../div[2]/span"
-                position="attributes"
-            >
-                <attribute name="attrs">{'invisible': True}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Make adjustments on `res_config_settings` to make it compatible with `remove_odoo_enterprise`.

When having `account_invoice_inter_company` installed:
![image](https://github.com/user-attachments/assets/1741c56a-dd25-4e2f-bf92-b9091cc5d571)

When having `account_invoice_inter_company` and `remove_odoo_enterprise`:
![image](https://github.com/user-attachments/assets/d0423cf9-3e17-441a-bc3d-b53bb05fc243)

We miss **Inter Company OCA features**