### PR TITLE
[16.0][FIX] product_category_company: revoke read permissions for external …

### DIFF
--- a/product_category_company/security/ir_rule.xml
+++ b/product_category_company/security/ir_rule.xml
@@ -4,7 +4,7 @@
         <field name="name">Product Category in multi-company</field>
         <field name="model_id" ref="model_product_category" />
         <field eval="True" name="global" />
-        <field name="perm_read" eval="False" />
+        <field name="perm_read" eval="True" />
         <field name="perm_write" eval="True" />
         <field name="perm_create" eval="True" />
         <field name="perm_unlink" eval="True" />


### PR DESCRIPTION
…categories

Set `product.category` read permissions to false in multi-company module to prevent listing categories from other companies. This change ensures that in a multi-company environment, product categories from one company are not visible to users of another company, maintaining data privacy and integrity across different companies within the same database.