### PR TITLE
[17.0][IMP-FIX] partner_multi_company: no longer define display_name as store

### DIFF
--- a/partner_multi_company/README.rst
+++ b/partner_multi_company/README.rst
@@ -84,6 +84,7 @@ Contributors
 
    -  Pedro M. Baeza <pedro.baeza@tecnativa.com>
    -  Vicent Cubells <vicent.cubells@tecnativa.com>
+   -  Pilar Vargas
 
 -  Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
 

--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -2,22 +2,13 @@
 # Copyright 2015-2019 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html.html
 
-from odoo import Command, _, api, fields, models
+from odoo import Command, _, api, models
 from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
     _inherit = ["multi.company.abstract", "res.partner"]
     _name = "res.partner"
-
-    # This is needed because after installation this field becomes
-    # unsearchable and unsortable. Which is not explicitly changed in this
-    # module and as such can be considered an undesired yield.
-    display_name = fields.Char(
-        compute="_compute_display_name",
-        store=True,
-        index=True,
-    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/partner_multi_company/readme/CONTRIBUTORS.md
+++ b/partner_multi_company/readme/CONTRIBUTORS.md
@@ -3,4 +3,5 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Pedro M. Baeza \<<pedro.baeza@tecnativa.com>\>
   - Vicent Cubells \<<vicent.cubells@tecnativa.com>\>
+  - Pilar Vargas
 - Kitti Upariphutthiphong \<<kittiu@ecosoft.co.th>\>

--- a/partner_multi_company/static/description/index.html
+++ b/partner_multi_company/static/description/index.html
@@ -431,6 +431,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;tecnativa.com">pedro.baeza&#64;tecnativa.com</a>&gt;</li>
 <li>Vicent Cubells &lt;<a class="reference external" href="mailto:vicent.cubells&#64;tecnativa.com">vicent.cubells&#64;tecnativa.com</a>&gt;</li>
+<li>Pilar Vargas</li>
 </ul>
 </li>
 <li>Kitti Upariphutthiphong &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>


### PR DESCRIPTION
In the partner_multi_company module, the display_name field had to be redefined as store and index because the module installation removed those field properties. As of v17 the field is no longer store so it is not necessary to redefine it as storable. In addition, this redefinition causes errors when printing reports because the field is not calculated when accessing and therefore only shows the data stored in the database, which is not updated until one of the fields of the dependency changes.

The issue in v10 why this redefinition was necessary: https://github.com/OCA/multi-company/issues/84

This PR resolves this issue: https://github.com/OCA/multi-company/issues/784

cc @tecnativa

@pedrobaeza @carlos-lopez-tecnativa please review
