### PR TITLE
[16.0][IMP] product_tax_multicompany_default: Extend ignored_company_ids context functionality

### DIFF
--- a/product_tax_multicompany_default/models/product.py
+++ b/product_tax_multicompany_default/models/product.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # Copyright 2018 Vicent Cubells - Tecnativa <vicent.cubells@tecnativa.com>
 # Copyright 2023 Eduardo de Miguel - Moduon <edu@moduon.team>
+# Copyright 2025 Sergio Bustamante - FactorLibre <sergio.bustamante@factorlibre.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from typing import List
@@ -101,6 +102,8 @@ class ProductTemplate(models.Model):
 
     def set_multicompany_taxes(self):
         self.ensure_one()
+        ignored_company_ids = self.env.context.get("ignored_company_ids", [])
+        ignored_taxes_id = self._get_ignored_taxes_id(ignored_company_ids) or []
         user_company = self.env.company
         customer_tax = self.taxes_id
         customer_tax_ids = customer_tax.ids
@@ -119,8 +122,8 @@ class ProductTemplate(models.Model):
         )
         # Clean taxes from other companies (cannot replace it with sudo)
         self._delete_product_taxes(
-            excl_customer_tax_ids=customer_tax_ids,
-            excl_supplier_tax_ids=supplier_tax_ids,
+            excl_customer_tax_ids=customer_tax_ids + ignored_taxes_id,
+            excl_supplier_tax_ids=supplier_tax_ids + ignored_taxes_id,
         )
         # Use list() to copy list
         match_customer_tax_ids = (
@@ -133,7 +136,10 @@ class ProductTemplate(models.Model):
             if default_supplier_tax_ids != supplier_tax_ids
             else None
         )
-        for company in obj.env["res.company"].search([("id", "!=", user_company.id)]):
+        company_ids = ignored_company_ids + [user_company.id]
+        if self.env.context.get("from_create", False):
+            company_ids = [user_company.id]
+        for company in obj.env["res.company"].search([("id", "not in", company_ids)]):
             customer_tax_ids.extend(
                 obj.taxes_by_company(
                     "account_sale_tax_id", company, match_customer_tax_ids
@@ -146,8 +152,8 @@ class ProductTemplate(models.Model):
             )
         self.write(
             {
-                "taxes_id": [(6, 0, customer_tax_ids)],
-                "supplier_taxes_id": [(6, 0, supplier_tax_ids)],
+                "taxes_id": [[4, tax] for tax in customer_tax_ids],
+                "supplier_taxes_id": [[4, tax] for tax in supplier_tax_ids],
             }
         )
 
@@ -155,8 +161,19 @@ class ProductTemplate(models.Model):
     def create(self, vals_list):
         new_products = super().create(vals_list)
         for product in new_products:
-            product.set_multicompany_taxes()
+            product.with_context(from_create=True).set_multicompany_taxes()
         return new_products
+
+    def _get_ignored_taxes_id(self, ignored_company_ids):
+        ignored_taxes_ids = False
+        if ignored_company_ids:
+            ignored_taxes_ids = (
+                self.env["account.tax"]
+                .sudo()
+                .search([("company_id", "in", ignored_company_ids)])
+                .ids
+            )
+        return ignored_taxes_ids
 
 
 class ProductProduct(models.Model):

--- a/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
+++ b/product_tax_multicompany_default/tests/test_product_tax_multicompany.py
@@ -265,3 +265,49 @@ class TestsProductTaxMulticompany(TransactionCase):
         self.assertTrue(product.divergent_company_taxes)
         product.set_multicompany_taxes()
         self.assertFalse(product.divergent_company_taxes)
+
+    @users("user_12")
+    def test_set_multicompany_taxes_ignored_company_ids(self):
+        # If purchase module is installed
+        # add purchase manager group to user_12
+        # to access the supplier_taxes_id field in the product view
+        try:
+            self.env.ref(
+                "purchase.group_purchase_manager", raise_if_not_found=True
+            ).sudo().users = [(4, self.user_12.id)]
+        except ValueError as e:
+            logging.info(e)  # Skipping configuration of purchase module
+        # # Create product with empty taxes
+        pf_u3_c1 = Form(self.env["product.product"].with_company(self.company_1))
+        pf_u3_c1.name = "Testing Product"
+        pf_u3_c1.taxes_id.clear()
+        pf_u3_c1.supplier_taxes_id.clear()
+        product = pf_u3_c1.save()
+        self.assertFalse(
+            product.sudo().taxes_id,
+            "Taxes not empty when initializing product",
+        )
+        # Fill taxes
+        pf_u3_c1.taxes_id.add(self.tax_30_cc1)
+        pf_u3_c1.supplier_taxes_id.add(self.tax_30_sc1)
+        product = pf_u3_c1.save()
+        self.assertEqual(
+            product.sudo().taxes_id,
+            self.tax_30_cc1,
+            "Taxes has been propagated before calling set_multicompany_taxes",
+        )
+        product.with_context(ignored_company_ids=self.company_2.ids).with_company(
+            self.company_1
+        ).set_multicompany_taxes()
+        company_1_taxes_fill = product.sudo().taxes_id.filtered(
+            lambda t: t.company_id == self.company_1
+        )
+        company_2_taxes_fill = product.sudo().taxes_id.filtered(
+            lambda t: t.company_id == self.company_2
+        )
+        self.assertEqual(
+            company_1_taxes_fill,
+            self.tax_30_cc1,
+            "Incorrect taxes when setting it for the first time in Company 1",
+        )
+        self.assertFalse(company_2_taxes_fill)


### PR DESCRIPTION
Give more functionality to `ignored_company_ids` context.

There could be cases where some companies could not apply to propagation, for example, if differs on country.

So here we add `ignored_company_ids` context into `set_multicompany_taxes()` in order to make the module inheritable to be able to exclude companies from tax propagation.

Taxes are already deleted before `self.write`, so replace `[6, 0, [ids]]` for `[[4, id] for id in ids]`