### PR TITLE
[OU][FIX][17.0]mail_multi_company:  Prevent column creation if already exists

### DIFF
--- a/mail_multicompany/migrations/17.0.1.0.0/pre-migration.py
+++ b/mail_multicompany/migrations/17.0.1.0.0/pre-migration.py
@@ -9,5 +9,7 @@ def migrate(cr, version):
     models = [env["mail.message"]]
     for model in models:
         table_name = model._table
-        if column_exists(cr, table_name, "company_id"):
+        if column_exists(cr, table_name, "company_id") and not column_exists(
+            cr, table_name, "record_company_id"
+        ):
             rename_column(cr, table_name, "company_id", "record_company_id")


### PR DESCRIPTION
The filed record_company could exist if another module already has create it. This additional check helps to get the process run smoothly