### PR TITLE
[15.0][IMP] product_multi_company: do not allow to remove a company from company_ids if there is stock or moves in that company

### DIFF
--- a/product_multi_company/models/product_template.py
+++ b/product_multi_company/models/product_template.py
@@ -1,10 +1,50 @@
 # Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 
 class ProductTemplate(models.Model):
     _inherit = ["multi.company.abstract", "product.template"]
     _name = "product.template"
     _description = "Product Template (Multi-Company)"
+
+    @api.constrains("company_ids")
+    def _check_company_ids(self):
+        for record in self:
+            if record.company_ids:
+                quants = self.env["stock.quant"].search(
+                    [
+                        ("product_id", "in", record.product_variant_ids.ids),
+                        ("company_id", "not in", record.company_ids.ids),
+                        ("quantity", "!=", 0),
+                        ("location_id.usage", "=", "internal"),
+                    ]
+                )
+                if quants:
+                    companies = quants.mapped("company_id")
+                    company_names = ", ".join(companies.mapped("name"))
+                    raise UserError(
+                        _(
+                            "Cannot remove the following companies because "
+                            "there are stock quantities associated with them: %s"
+                        )
+                        % company_names
+                    )
+                moves = self.env["stock.move"].search(
+                    [
+                        ("product_id", "in", record.product_variant_ids.ids),
+                        ("company_id", "not in", record.company_ids.ids),
+                    ]
+                )
+                if moves:
+                    companies = moves.mapped("company_id")
+                    company_names = ", ".join(companies.mapped("name"))
+                    raise UserError(
+                        _(
+                            "Cannot remove the following companies because "
+                            "there are stock moves associated with them: %s"
+                        )
+                        % company_names
+                    )

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -2,7 +2,7 @@
 # Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import common
 
 from .common import ProductMultiCompanyCommon
@@ -93,3 +93,55 @@ class TestProductMultiCompany(ProductMultiCompanyCommon, common.TransactionCase)
             "('company_id', '=', False)]"
         )
         self.assertEqual(rule.domain_force, domain)
+
+    def test_remove_company_with_quants_or_moves(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "type": "product",
+                "company_ids": [(6, 0, [self.company_1.id, self.company_2.id])],
+            }
+        )
+        internal_loc = self.env["stock.location"].create(
+            {
+                "name": "Test Internal Location",
+                "usage": "internal",
+                "company_id": self.company_1.id,
+            }
+        )
+        dest_loc = self.env["stock.location"].create(
+            {
+                "name": "Test Customer Location",
+                "usage": "customer",
+                "company_id": self.company_1.id,
+            }
+        )
+        quant = self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": internal_loc.id,
+                "company_id": self.company_1.id,
+                "quantity": 10,
+            }
+        )
+        with self.assertRaises(UserError) as error_quant:
+            product.write({"company_ids": [(6, 0, [self.company_2.id])]})
+        self.assertIn("stock quantities", str(error_quant.exception))
+        quant.unlink()
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Stock Move",
+                "product_id": product.id,
+                "product_uom_qty": 10,
+                "product_uom": product.uom_id.id,
+                "location_id": internal_loc.id,
+                "location_dest_id": dest_loc.id,
+                "company_id": self.company_1.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move._action_done()
+        with self.assertRaises(UserError) as error_move:
+            product.write({"company_ids": [(6, 0, [self.company_2.id])]})
+        self.assertIn("stock moves", str(error_move.exception))


### PR DESCRIPTION
This PR ensures that a company cannot be removed from `company_ids` if there are quants or stock moves associated with it.  

Without this restriction, access errors may occur when checking Stock Valuation and other reports 

Odoo already prevents changes to `company_id` when there are existing quants or moves. This PR extends the same logic to `company_ids`.