### PR TITLE
[17.0][FW][IMP] account_invoice_inter_company: add setting to disable or enable intercompany invoicing

### DIFF
--- a/account_invoice_inter_company/README.rst
+++ b/account_invoice_inter_company/README.rst
@@ -50,8 +50,8 @@ Configuration
 To configure this module, you need to go to the menu *Settings > General
 Settings*, go to the tab *Companies / Inter Company OCA features*
 
-You now have access to other options *Intercompany user for invoices*
-and *Invoice Auto Validation*.
+You now have access to other options *Generate Intercompany Invoices*,
+*Intercompany user for invoices* and *Invoice Auto Validation*.
 
 To customize products sharing don't hesitate to override
 \_compute_share_product() in res.company model.
@@ -59,13 +59,13 @@ To customize products sharing don't hesitate to override
 Known issues / Roadmap
 ======================
 
-   - This module cannot be fully used in combination with
-     remove_odoo_entreprise module. If you need both, uninstall
-     remove_odoo_entreprise, complete settings with
-     account_invoice_inter_company and then re-install
-     remove_odoo_entreprise.
-   - Product mapping: would be nice to have a matrix with the products
-     on the left side and on the top row the companies.
+   -  This module cannot be fully used in combination with
+      remove_odoo_entreprise module. If you need both, uninstall
+      remove_odoo_entreprise, complete settings with
+      account_invoice_inter_company and then re-install
+      remove_odoo_entreprise.
+   -  Product mapping: would be nice to have a matrix with the products
+      on the left side and on the top row the companies.
 
 Bug Tracker
 ===========
@@ -89,26 +89,26 @@ Authors
 Contributors
 ------------
 
-- Odoo S.A. (original module inter_company_rules)
-- Andrea Stirpe <a.stirpe@onestein.nl>
-- Adria Gil Sorribes <adria.gil@forgeflow.com>
-- Christopher Ormaza <chris.ormaza@forgeflow.com>
-- \`Akretion <https://www.akretion.com>\`:
+-  Odoo S.A. (original module inter_company_rules)
+-  Andrea Stirpe <a.stirpe@onestein.nl>
+-  Adria Gil Sorribes <adria.gil@forgeflow.com>
+-  Christopher Ormaza <chris.ormaza@forgeflow.com>
+-  \`Akretion <https://www.akretion.com>\`:
 
-  - Chafique Delli <chafique.delli@akretion.com>
-  - Alexis de Lattre <alexis.delattre@akretion.com>
-  - David Beal <david.beal@akretion.com>
+   -  Chafique Delli <chafique.delli@akretion.com>
+   -  Alexis de Lattre <alexis.delattre@akretion.com>
+   -  David Beal <david.beal@akretion.com>
 
-- \`Tecnativa <https://www.tecnativa.com>\`:
+-  \`Tecnativa <https://www.tecnativa.com>\`:
 
-  - Jairo Llopis
-  - David Vidal
-  - Pedro M. Baeza
+   -  Jairo Llopis
+   -  David Vidal
+   -  Pedro M. Baeza
 
-- Isaac Gallart <igallart@puntsistemes.es>
-- \`Komit <https://komit-consulting.com>\`:
+-  Isaac Gallart <igallart@puntsistemes.es>
+-  \`Komit <https://komit-consulting.com>\`:
 
-  - Cuong Nguyen Mtm <cuong.nmtm@komit-consulting.com>
+   -  Cuong Nguyen Mtm <cuong.nmtm@komit-consulting.com>
 
 Maintainers
 -----------

--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -51,6 +51,13 @@ class AccountMove(models.Model):
             dest_company = src_invoice._find_company_from_invoice_partner()
             if not dest_company:
                 continue
+            # If one of the involved companies have the intercompany
+            # setting disabled, skip
+            if (
+                not dest_company.intercompany_invoicing
+                or not src_invoice.company_id.intercompany_invoicing
+            ):
+                continue
             intercompany_user = dest_company.intercompany_invoice_user_id
             if intercompany_user:
                 src_invoice = src_invoice.with_user(intercompany_user).sudo()

--- a/account_invoice_inter_company/models/res_company.py
+++ b/account_invoice_inter_company/models/res_company.py
@@ -17,6 +17,14 @@ class ResCompany(models.Model):
         help="Responsible user for creation of invoices triggered by "
         "intercompany rules.",
     )
+    intercompany_invoicing = fields.Boolean(
+        string="Generate Inter company Invoices",
+        help="Enable intercompany invoicing: "
+        "\n* Generate a Customer Invoice when a bill with this company is created."
+        "\n* Generate a Vendor Bill when an invoice with this company as a customer"
+        " is created.",
+        default=True,
+    )
 
     def _get_user_domain(self):
         self.ensure_one()

--- a/account_invoice_inter_company/models/res_config_settings.py
+++ b/account_invoice_inter_company/models/res_config_settings.py
@@ -20,3 +20,12 @@ class ResConfigSettings(models.TransientModel):
         "intercompany rules. If not set the user initiating the"
         "transaction will be used",
     )
+    intercompany_invoicing = fields.Boolean(
+        string="Generate Inter company Invoices",
+        related="company_id.intercompany_invoicing",
+        help="Enable intercompany invoicing: "
+        "\n * Generate a Customer Invoice when a bill with this company is created."
+        "\n * Generate a Vendor Bill when an invoice with this company as a customer"
+        " is created.",
+        readonly=False,
+    )

--- a/account_invoice_inter_company/readme/CONFIGURE.md
+++ b/account_invoice_inter_company/readme/CONFIGURE.md
@@ -2,7 +2,7 @@ To configure this module, you need to go to the menu *Settings \>
 General Settings*, go to the tab *Companies / Inter Company OCA
 features*
 
-You now have access to other options *Intercompany user for invoices* and
+You now have access to other options *Generate Intercompany Invoices*, *Intercompany user for invoices* and
 *Invoice Auto Validation*.
 
 To customize products sharing don't hesitate to override

--- a/account_invoice_inter_company/static/description/index.html
+++ b/account_invoice_inter_company/static/description/index.html
@@ -397,8 +397,8 @@ invoice in company B.</p>
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p>To configure this module, you need to go to the menu <em>Settings &gt; General
 Settings</em>, go to the tab <em>Companies / Inter Company OCA features</em></p>
-<p>You now have access to other options <em>Intercompany user for invoices</em>
-and <em>Invoice Auto Validation</em>.</p>
+<p>You now have access to other options <em>Generate Intercompany Invoices</em>,
+<em>Intercompany user for invoices</em> and <em>Invoice Auto Validation</em>.</p>
 <p>To customize products sharing don’t hesitate to override
 _compute_share_product() in res.company model.</p>
 </div>

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -20,6 +20,7 @@ class TestAccountInvoiceInterCompanyBase(TransactionCase):
             {
                 "name": "Company A",
                 "invoice_auto_validation": True,
+                "intercompany_invoicing": True,
             }
         )
         cls.partner_company_a = cls.env["res.partner"].create(
@@ -30,6 +31,7 @@ class TestAccountInvoiceInterCompanyBase(TransactionCase):
             {
                 "name": "Company B",
                 "invoice_auto_validation": True,
+                "intercompany_invoicing": True,
             }
         )
         cls.partner_company_b = cls.env["res.partner"].create(
@@ -575,3 +577,16 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
         )
         self.assertEqual(len(invoices), 1)
         return invoices
+
+    def test_confirm_invoice_intercompany_disabled(self):
+        # ensure the catalog is shared
+        self.env.ref("product.product_comp_rule").write({"active": False})
+        # Disable the configuration in company A
+        self.company_a.intercompany_invoicing = False
+        # Confirm the invoice of company A
+        self.invoice_company_a.with_user(self.user_company_a.id).action_post()
+        # Check that no destination invoice has been created in company B
+        invoices = self.account_move_obj.with_user(self.user_company_b.id).search(
+            [("auto_invoice_id", "=", self.invoice_company_a.id)]
+        )
+        self.assertFalse(invoices)

--- a/account_invoice_inter_company/views/res_config_settings_view.xml
+++ b/account_invoice_inter_company/views/res_config_settings_view.xml
@@ -17,7 +17,15 @@
                 >
                     <div class="text-decoration-underline mt8 mb8">Invoice</div>
                     <div class="content-group" string="Invoice">
-                        <div>
+                        <div id="intercompany_invoicing">
+                            <label
+                                string="Generate Intercompany Invoices"
+                                for="intercompany_invoicing"
+                                class="o_light_label mr8"
+                            />
+                            <field name="intercompany_invoicing" class="oe_inline" />
+                        </div>
+                        <div invisible="not intercompany_invoicing">
                             <label
                                 for="intercompany_invoice_user_id"
                                 string="Invoices User"
@@ -28,7 +36,7 @@
                                 class="oe_inline"
                             />
                         </div>
-                        <div>
+                        <div invisible="not intercompany_invoicing">
                             <label
                                 for="invoice_auto_validation"
                                 class="o_light_label mr8"


### PR DESCRIPTION
This commit adds a new setting called intercompany_invoicing that allows the user to activate or deactivate the intercompany invoicing. When positing an intercompany invoice, if one of the companies have the setting disabled, the other invoice will not be automatically created.

FW of https://github.com/OCA/multi-company/pull/631