### PR TITLE
[14.0][FIX] purchase_sale_inter_company: support multistep deliveries

### DIFF
--- a/purchase_sale_inter_company/README.rst
+++ b/purchase_sale_inter_company/README.rst
@@ -72,6 +72,10 @@ Known issues / Roadmap
   taxes, etc. A mechanism for synching from the sale to the purchase order would be
   needed.
 
+* Module is not very robust in complex situations, such as multi-step receipts
+  and multi-step deliveries, with backorders. Multi-step receipts
+  could be improved further.
+
 Bug Tracker
 ===========
 

--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -29,7 +29,10 @@ class SaleOrder(models.Model):
                 and dest_company
                 and dest_company.sync_picking
             ):
-                pickings = sale_order.picking_ids
+                # we only want to sync the final outgoing pickings...
+                pickings = sale_order.picking_ids.filtered(
+                    lambda x: x.location_dest_id.usage == "customer"
+                )
                 po_company = sale_order.sudo().auto_purchase_order_id.company_id
                 purchase_picking = sale_order.auto_purchase_order_id.with_user(
                     po_company.intercompany_sale_user_id.id

--- a/purchase_sale_inter_company/readme/ROADMAP.rst
+++ b/purchase_sale_inter_company/readme/ROADMAP.rst
@@ -3,3 +3,7 @@
   transmitted to the purchase so both documents couldn't have different total amounts,
   taxes, etc. A mechanism for synching from the sale to the purchase order would be
   needed.
+
+* Module is not very robust in complex situations, such as multi-step receipts
+  and multi-step deliveries, with backorders. Multi-step receipts
+  could be improved further.

--- a/purchase_sale_inter_company/static/description/index.html
+++ b/purchase_sale_inter_company/static/description/index.html
@@ -410,6 +410,9 @@ This would be interesting in the case of price changes and discounts, that would
 transmitted to the purchase so both documents couldn’t have different total amounts,
 taxes, etc. A mechanism for synching from the sale to the purchase order would be
 needed.</li>
+<li>Module is not very robust in complex situations, such as multi-step receipts
+and multi-step deliveries, with backorders. Multi-step receipts
+could be improved further.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -377,6 +377,97 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         self.assertTrue(len(sale.picking_ids) > 1)
         self.assertEqual(len(purchase.picking_ids), len(sale.picking_ids))
 
+    def test_sync_picking_multi_step(self):
+        self.company_a.sync_picking = True
+        self.warehouse_a.reception_steps = "two_steps"
+        self.company_b.sync_picking = True
+        self.warehouse_c.delivery_steps = "pick_ship"
+
+        purchase = self._create_purchase_order(
+            self.partner_company_b, self.consumable_product
+        )
+        sale = self._approve_po(purchase)
+
+        self.assertEqual(len(purchase.picking_ids), 1)
+        # the move in the receipt should have a "next move" due to "two_steps"
+        self.assertTrue(purchase.picking_ids.move_lines.move_dest_ids)
+        self.assertEqual(len(sale.picking_ids), 2)
+
+        po_picking_id = purchase.picking_ids
+        po_internal_pick_id = po_picking_id.move_lines.move_dest_ids.picking_id
+        so_picking_id = sale.picking_ids.filtered(
+            lambda x: x.location_dest_id.usage == "customer"
+        )
+        so_internal_pick_id = sale.picking_ids - so_picking_id
+
+        self.assertTrue(
+            all(
+                (po_picking_id, po_internal_pick_id, so_picking_id, so_internal_pick_id)
+            )
+        )
+
+        # check po_picking state
+        self.assertEqual(po_picking_id.state, "waiting")
+
+        # validate the SO internal picking
+        so_internal_pick_id.move_lines.quantity_done = 2
+        so_internal_pick_id.state = "done"
+        wizard_data = so_internal_pick_id.with_user(
+            self.user_company_b
+        ).button_validate()
+        wizard = (
+            self.env["stock.backorder.confirmation"]
+            .with_context(**wizard_data.get("context"))
+            .create({})
+        )
+        wizard.process()
+
+        # check po_picking state
+        self.assertEqual(po_picking_id.state, "waiting")
+
+        # validate the SO picking
+
+        so_picking_id.move_lines.quantity_done = 2
+
+        self.assertNotEqual(po_picking_id, so_picking_id)
+        self.assertNotEqual(
+            po_picking_id.move_lines.quantity_done,
+            so_picking_id.move_lines.quantity_done,
+        )
+        self.assertEqual(
+            po_picking_id.move_lines.product_qty,
+            so_picking_id.move_lines.product_qty,
+        )
+
+        so_picking_id.state = "done"
+        wizard_data = so_picking_id.with_user(self.user_company_b).button_validate()
+        wizard = (
+            self.env["stock.backorder.confirmation"]
+            .with_context(**wizard_data.get("context"))
+            .create({})
+        )
+        wizard.process()
+
+        # Quantities should have been synced
+        self.assertNotEqual(po_picking_id, so_picking_id)
+        self.assertEqual(
+            po_picking_id.move_lines.quantity_done,
+            so_picking_id.move_lines.quantity_done,
+        )
+
+        # Check picking state
+        self.assertEqual(po_picking_id.state, so_picking_id.state)
+
+        # A backorder should have been made for both steps of sale
+        self.assertEqual(len(sale.picking_ids), 4)
+        # An additional receipt should have been created for the PO
+        self.assertEqual(len(purchase.picking_ids), 2)
+        done_purchase_picking = purchase.picking_ids.filtered(
+            lambda x: x.state == "done"
+        )
+        self.assertEqual(len(done_purchase_picking), 1)
+        self.assertEqual(done_purchase_picking, po_picking_id)
+
     def test_sync_picking_no_backorder(self):
         self.company_a.sync_picking = True
         self.company_b.sync_picking = True


### PR DESCRIPTION
Before this commit, if the company selling had setup 2- or 3-step deliveries on its warehouse, 2 or 3 receipts would be created on the PO side.

When synchronizing, we only need to consider the final outgoing picking, and not the intermediate pickings.