### PR TITLE
[IMP] mail_template_multi_company

### DIFF
--- a/mail_template_multi_company/README.rst
+++ b/mail_template_multi_company/README.rst
@@ -76,6 +76,9 @@ Contributors
 * Olivier Laurent <olivier.laurent@acsone.eu>
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 * Andrea Stirpe <a.stirpe@onestein.nl>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/mail_template_multi_company/models/__init__.py
+++ b/mail_template_multi_company/models/__init__.py
@@ -1,1 +1,2 @@
+from . import ir_model_data
 from . import mail_template

--- a/mail_template_multi_company/models/ir_model_data.py
+++ b/mail_template_multi_company/models/ir_model_data.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Simone Rubino - PyTech
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IRModelData(models.Model):
+    _inherit = "ir.model.data"
+
+    @api.model
+    def xmlid_to_res_model_res_id(self, xmlid, raise_if_not_found=False):
+        res_model, res_id = super().xmlid_to_res_model_res_id(
+            xmlid,
+            raise_if_not_found=raise_if_not_found,
+        )
+        if res_model == "mail.template" and res_id:
+            module, xmlid = xmlid.split(".")
+            res_model, res_id = self.check_object_reference(
+                module,
+                xmlid,
+                raise_on_access_error=raise_if_not_found,
+            )
+        return res_model, res_id

--- a/mail_template_multi_company/readme/CONTRIBUTORS.rst
+++ b/mail_template_multi_company/readme/CONTRIBUTORS.rst
@@ -1,3 +1,6 @@
 * Olivier Laurent <olivier.laurent@acsone.eu>
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 * Andrea Stirpe <a.stirpe@onestein.nl>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/mail_template_multi_company/static/description/index.html
+++ b/mail_template_multi_company/static/description/index.html
@@ -426,6 +426,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Olivier Laurent &lt;<a class="reference external" href="mailto:olivier.laurent&#64;acsone.eu">olivier.laurent&#64;acsone.eu</a>&gt;</li>
 <li>Souheil Bejaoui &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
 <li>Andrea Stirpe &lt;<a class="reference external" href="mailto:a.stirpe&#64;onestein.nl">a.stirpe&#64;onestein.nl</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mail_template_multi_company/tests/__init__.py
+++ b/mail_template_multi_company/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_ir_model_data

--- a/mail_template_multi_company/tests/test_ir_model_data.py
+++ b/mail_template_multi_company/tests/test_ir_model_data.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Simone Rubino - PyTech
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import AccessError
+from odoo.tests import SavepointCase
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+
+class TestIRModelData(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.other_company = cls.env["res.company"].create(
+            {
+                "name": "Test other Company",
+            }
+        )
+
+        cls.other_company_template = cls.env["mail.template"].create(
+            {
+                "name": "Test other company template",
+                "company_id": cls.other_company.id,
+            }
+        )
+        cls.other_company_template_data = cls.env["ir.model.data"].create(
+            {
+                "module": "test_module",
+                "name": "test_xmlid",
+                "model": cls.other_company_template._name,
+                "res_id": cls.other_company_template.id,
+            }
+        )
+        cls.other_company_template_xmlid = ".".join(
+            [
+                cls.other_company_template_data.module,
+                cls.other_company_template_data.name,
+            ]
+        )
+
+        company_user = mail_new_test_user(
+            cls.env,
+            login="Test company user",
+            company_id=cls.company.id,
+            company_ids=cls.company.ids,
+        )
+
+        cls.env = cls.env(user=company_user)
+        cls.cr = cls.env.cr
+
+    def test_ref_xmlid_not_found(self):
+        """
+        When a template is found by XMLID but is in another company,
+        behave as if it wasn't found.
+        """
+        # Arrange
+        company = self.env.company
+        template_sudo = self.env(su=True).ref(self.other_company_template_xmlid)
+        # pre-condition
+        self.assertTrue(template_sudo)
+        self.assertNotEqual(template_sudo.company_id, company)
+
+        # Act
+        with self.assertRaises(AccessError) as ae:
+            self.env.ref(self.other_company_template_xmlid, raise_if_not_found=True)
+        exc_message = ae.exception.args[0]
+        template = self.env.ref(
+            self.other_company_template_xmlid, raise_if_not_found=False
+        )
+
+        # Assert
+        self.assertIn("Not enough access rights", exc_message)
+        self.assertFalse(template)


### PR DESCRIPTION
This improvment fixes the following use case:
1. Install `mail_template_multi_company` and `account`
2. Create another company **company_2**
3. Edit the email template `account.email_template_edi_invoice` and set its company to the new company **company_2**
4. Go back to the original company
5. In an invoice, click on the "Send invoice"

Before this PR:
An `AccessError` is raised because the template `account.email_template_edi_invoice` is not accessible, the relevant part of the stack is:
<details><summary>Stack</summary>
<pre>
[...]
  File "/opt/odoo/auto/addons/account/models/account_move.py", line 2895, in action_invoice_sent
    lang = template._render_lang(self.ids)[self.id]
  File "/opt/odoo/auto/addons/mail/models/mail_render_mixin.py", line 420, in _render_lang
    rendered_langs = self._render_template(self.lang, self.model, res_ids)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1022, in __get__
    record._fetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3085, in _fetch_field
    self._read(fnames)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3205, in _read
    raise self.env['ir.rule']._make_access_error('read', forbidden)
odoo.exceptions.AccessError: Due to security restrictions, you are not allowed to access 'Email Templates' (mail.template) records.
</pre>
</details> 


After this PR:
The email composer is opened, empty.

Additional notes:
A similar error is raised also for `sale` module (and maybe others), and its templates used to send a sale order.