### PR TITLE
[IMP] mail_template_multicompany: Fall back on substitute

### DIFF
--- a/mail_template_multi_company/README.rst
+++ b/mail_template_multi_company/README.rst
@@ -30,6 +30,13 @@ Mail Template Multi Company
 
 This module add multi-company management to mail templates.
 
+This module also adds a fallback mechanism for templates that are hardcoded using their XMLID.
+For example: the `sale` module will propose the template `sale.mail_template_sale_confirmation` when an order is confirmed.
+
+If the template is not found due to access rules (for instance because it has been linked to another company), nothing is found.
+With this module, the field "Original XMLID template" can be filled with the template that corresponds to `sale.mail_template_sale_confirmation` (that is done automatically if the template is copied).
+With this configuration, the new template will be found.
+
 **Table of contents**
 
 .. contents::

--- a/mail_template_multi_company/models/ir_model_data.py
+++ b/mail_template_multi_company/models/ir_model_data.py
@@ -14,10 +14,22 @@ class IRModelData(models.Model):
             raise_if_not_found=raise_if_not_found,
         )
         if res_model == "mail.template" and res_id:
+            original_res_id = res_id
             module, xmlid = xmlid.split(".")
             res_model, res_id = self.check_object_reference(
                 module,
                 xmlid,
                 raise_on_access_error=raise_if_not_found,
             )
+            if not res_id:
+                # Fallback on the first substitute that can be accessed
+                template_sudo = self.env["mail.template"].sudo().browse(original_res_id)
+                substitutes = template_sudo.substitute_xmlid_mail_template_ids
+                accessible_substitute = self.env["mail.template"].search(
+                    [
+                        ("id", "in", substitutes.ids),
+                    ],
+                    limit=1,
+                )
+                res_id = accessible_substitute.id
         return res_model, res_id

--- a/mail_template_multi_company/models/mail_template.py
+++ b/mail_template_multi_company/models/mail_template.py
@@ -1,4 +1,5 @@
 # Copyright 2017 ACSONE SA/NV
+# Copyright 2025 Simone Rubino - PyTech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -12,3 +13,25 @@ class MailTemplate(models.Model):
         "res.company",
         ondelete="set null",
     )
+    original_xmlid_mail_template_id = fields.Many2one(
+        comodel_name="mail.template",
+        string="Original XMLID template",
+        help="Mail Template that corresponds to a record having a XMLID. "
+        "This record will be used when the record having a XMLID is found "
+        "but cannot be accessed.",
+    )
+    substitute_xmlid_mail_template_ids = fields.One2many(
+        comodel_name="mail.template",
+        inverse_name="original_xmlid_mail_template_id",
+        string="Substitutes for XMLID template",
+        help="Mail Templates that correspond to this record's XMLID. "
+        "When this record is searched by XMLID but cannot be accessed, "
+        "the first accessible substitute will be found instead.",
+    )
+
+    def copy(self, default=None):
+        has_xmlid = self.get_external_id()[self.id]
+        if has_xmlid:
+            default = dict(default or {})
+            default["original_xmlid_mail_template_id"] = self.id
+        return super().copy(default=default)

--- a/mail_template_multi_company/readme/DESCRIPTION.rst
+++ b/mail_template_multi_company/readme/DESCRIPTION.rst
@@ -1,1 +1,8 @@
 This module add multi-company management to mail templates.
+
+This module also adds a fallback mechanism for templates that are hardcoded using their XMLID.
+For example: the `sale` module will propose the template `sale.mail_template_sale_confirmation` when an order is confirmed.
+
+If the template is not found due to access rules (for instance because it has been linked to another company), nothing is found.
+With this module, the field "Original XMLID template" can be filled with the template that corresponds to `sale.mail_template_sale_confirmation` (that is done automatically if the template is copied).
+With this configuration, the new template will be found.

--- a/mail_template_multi_company/static/description/index.html
+++ b/mail_template_multi_company/static/description/index.html
@@ -371,6 +371,11 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/multi-company/tree/14.0/mail_template_multi_company"><img alt="OCA/multi-company" src="https://img.shields.io/badge/github-OCA%2Fmulti--company-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/multi-company-14-0/multi-company-14-0-mail_template_multi_company"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/multi-company&amp;target_branch=14.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module add multi-company management to mail templates.</p>
+<p>This module also adds a fallback mechanism for templates that are hardcoded using their XMLID.
+For example: the <cite>sale</cite> module will propose the template <cite>sale.mail_template_sale_confirmation</cite> when an order is confirmed.</p>
+<p>If the template is not found due to access rules (for instance because it has been linked to another company), nothing is found.
+With this module, the field “Original XMLID template” can be filled with the template that corresponds to <cite>sale.mail_template_sale_confirmation</cite> (that is done automatically if the template is copied).
+With this configuration, the new template will be found.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/mail_template_multi_company/tests/test_ir_model_data.py
+++ b/mail_template_multi_company/tests/test_ir_model_data.py
@@ -72,3 +72,30 @@ class TestIRModelData(SavepointCase):
         # Assert
         self.assertIn("Not enough access rights", exc_message)
         self.assertFalse(template)
+
+    def test_substitute(self):
+        """
+        When a template is not found by XMLID but has a substitute,
+        the substitute is found instead.
+        """
+        # Arrange
+        company = self.env.company
+        other_company_template = self.other_company_template
+        copied_other_company_template = other_company_template.copy(
+            default={
+                "company_id": company.id,
+            },
+        )
+        # pre-condition
+        self.assertEqual(
+            copied_other_company_template.original_xmlid_mail_template_id,
+            other_company_template,
+        )
+
+        # Act
+        template = self.env.ref(
+            self.other_company_template_xmlid, raise_if_not_found=False
+        )
+
+        # Assert
+        self.assertEqual(template, copied_other_company_template)

--- a/mail_template_multi_company/views/mail_template.xml
+++ b/mail_template_multi_company/views/mail_template.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017 Acsone Sa/Nv
+     Copyright 2025 Simone Rubino - PyTech
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="mail_template_form_view" model="ir.ui.view">
@@ -12,6 +13,10 @@
                     name="company_id"
                     options="{'no_open': True, 'no_create': True}"
                     groups="base.group_multi_company"
+                />
+                <field
+                    name="original_xmlid_mail_template_id"
+                    groups="base.group_no_one"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
When a template corresponding to a XMLID is not accessible, find one of its configured substitutes.

This is useful when other modules find a mail template by XMLID but that cannot be accessed: currently (thanks to https://github.com/OCA/multi-company/pull/818) no template is found.
This happens in https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/addons/sale/models/sale.py#L840-L852 for instance.

With this change, another template can be linked to the template identified by the XMLID so that the new template is found instead.