### PR TITLE
[16.0][IMP] purchase_sale_inter_company: do not require user, be able to use current user

### DIFF
--- a/purchase_sale_inter_company/views/res_config_view.xml
+++ b/purchase_sale_inter_company/views/res_config_view.xml
@@ -25,11 +25,7 @@
                     attrs="{'invisible':['|', ('company_id', '=', False), ('so_from_po', '=', False)]}"
                 >
                     <label for="intercompany_sale_user_id" class="o_light_label" />
-                    <field
-                        name="intercompany_sale_user_id"
-                        attrs="{'required': [('so_from_po', '=', True)]}"
-                        class="oe_inline"
-                    />
+                    <field name="intercompany_sale_user_id" class="oe_inline" />
                     <br />
                     <field name="sale_auto_validation" class="oe_inline" />
                     <label for="sale_auto_validation" class="oe_inline o_light_label" />


### PR DESCRIPTION
In most places dupe code equivalent to this is used.

`intercompany_user = (
            self.intercompany_sale_line_id.sudo().company_id.intercompany_sale_user_id
            or self.env.user
        )`

A function called _get_intercompany_user() could be implemented to pick the proper user (create_uid or current user, as it is by default when the required field is not set). 