### PR TITLE
[FIX] mail_template_multi_company: Only check access rules

### DIFF
--- a/mail_template_multi_company/models/ir_model_data.py
+++ b/mail_template_multi_company/models/ir_model_data.py
@@ -13,7 +13,15 @@ class IRModelData(models.Model):
             xmlid,
             raise_if_not_found=raise_if_not_found,
         )
-        if res_model == "mail.template" and res_id:
+        if (
+            res_model == "mail.template"
+            and res_id
+            and self.env["ir.model.access"].check(
+                res_model,
+                "read",
+                raise_exception=False,
+            )
+        ):
             original_res_id = res_id
             module, xmlid = xmlid.split(".")
             res_model, res_id = self.check_object_reference(

--- a/mail_template_multi_company/tests/test_ir_model_data.py
+++ b/mail_template_multi_company/tests/test_ir_model_data.py
@@ -99,3 +99,27 @@ class TestIRModelData(SavepointCase):
 
         # Assert
         self.assertEqual(template, copied_other_company_template)
+
+    def test_only_access_rule(self):
+        """If a user has no access rights to email templates,
+        do not raise an AccessError.
+        """
+        # Arrange
+        user = self.env.ref("base.demo_user0")
+        user_env = self.env(user=user)
+        # pre-condition
+        self.assertFalse(
+            user_env["ir.model.access"].check(
+                "mail.template",
+                "read",
+                raise_exception=False,
+            )
+        )
+
+        # Act
+        template = user_env.ref(
+            self.other_company_template_xmlid, raise_if_not_found=False
+        )
+
+        # Assert
+        self.assertTrue(template)


### PR DESCRIPTION
Fix the following use-case:

1. A contact is granted portal access
2. The user opens the provided link to set the password
3. The user sets the password and logs in

**Current behavior**
The confirmation email is not sent (https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/addons/auth_signup/controllers/main.py#L43) and an error is shown in the login page: 
![image](https://github.com/user-attachments/assets/9a1b92eb-a310-4307-82e0-6caf2e5039c4)

**Expected behavior**
The user can login