### PR TITLE
[14.0][IMP] product supplierinfo intercompany[_multi_company]: refactor, archiving

### DIFF
--- a/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
+++ b/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
@@ -23,6 +23,7 @@ class ProductIntercompanySupplierMixin(models.AbstractModel):
             "name": pricelist.company_id.partner_id.id,
             "company_id": False,
             "price": price,
+            "currency_id": pricelist.currency_id.id,
         }
         return res
 

--- a/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
+++ b/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
@@ -24,6 +24,7 @@ class ProductIntercompanySupplierMixin(models.AbstractModel):
             "company_id": False,
             "price": price,
             "currency_id": pricelist.currency_id.id,
+            "delay": pricelist.intercompany_supplier_lead_time,
         }
         return res
 

--- a/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
+++ b/product_supplierinfo_intercompany/models/product_intercompany_supplier_mixin.py
@@ -43,15 +43,28 @@ class ProductIntercompanySupplierMixin(models.AbstractModel):
             ):
                 domain = record._get_intercompany_supplier_info_domain(pricelist)
                 supplierinfo = record.env["product.supplierinfo"].search(domain)
-                if (
-                    record._has_intercompany_price(pricelist)
-                    and record.sale_ok
-                    and record.purchase_ok
-                ):
-                    vals = record._prepare_intercompany_supplier_info(pricelist)
-                    if supplierinfo:
-                        supplierinfo.write(vals)
-                    else:
-                        supplierinfo.create(vals)
-                elif supplierinfo:
-                    supplierinfo.sudo().unlink()
+                record._synchronise_supplier_info_for_record(pricelist, supplierinfo)
+
+    def _synchronise_supplier_info_for_record(self, pricelist, supplierinfo):
+        self.ensure_one()
+        if self._condition_supplierinfo_create_or_update(pricelist, supplierinfo):
+            vals = self._prepare_intercompany_supplier_info(pricelist)
+            if supplierinfo:
+                supplierinfo.write(vals)
+            else:
+                supplierinfo.create(vals)
+        elif self._condition_supplierinfo_unlink(pricelist, supplierinfo):
+            supplierinfo.sudo().unlink()
+
+    def _condition_supplierinfo_create_or_update(self, pricelist, supplierinfo):
+        self.ensure_one()
+        return (
+            self._has_intercompany_price(pricelist)
+            and self.sale_ok
+            and self.purchase_ok
+            and self.active
+        )
+
+    def _condition_supplierinfo_unlink(self, pricelist, supplierinfo):
+        self.ensure_one()
+        return bool(supplierinfo) or (not self.active)

--- a/product_supplierinfo_intercompany/models/product_pricelist.py
+++ b/product_supplierinfo_intercompany/models/product_pricelist.py
@@ -43,3 +43,13 @@ class ProductPricelist(models.Model):
         self.sudo().with_context(automatic_intercompany_sync=True).mapped(
             "generated_supplierinfo_ids"
         ).unlink()
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "active" in vals:
+            to_sync = self.filtered("is_intercompany_supplier")
+            if vals["active"]:
+                to_sync._active_intercompany()
+            else:
+                to_sync._unactive_intercompany()
+        return res

--- a/product_supplierinfo_intercompany/models/product_pricelist.py
+++ b/product_supplierinfo_intercompany/models/product_pricelist.py
@@ -12,6 +12,10 @@ class ProductPricelist(models.Model):
         default=False, inverse="_inverse_intercompany_supplier"
     )
 
+    intercompany_supplier_lead_time = fields.Float(
+        default=0, help="Vendor pricelist lead time, in days."
+    )
+
     generated_supplierinfo_ids = fields.One2many(
         comodel_name="product.supplierinfo",
         inverse_name="intercompany_pricelist_id",

--- a/product_supplierinfo_intercompany/models/product_template.py
+++ b/product_supplierinfo_intercompany/models/product_template.py
@@ -65,9 +65,18 @@ class ProductTemplate(models.Model):
         return res
 
     def write(self, vals):
-        res = super(ProductTemplate, self).write(vals)
-        for rec in self:
-            rec.update_intercompany_prices()
+        res = super().write(vals)
+        if (
+            "sale_ok" in vals
+            or "purchase_ok" in vals
+            or "list_price" in vals
+            or "standard_price" in vals
+            or "company_id" in vals
+            or "company_ids" in vals
+            or "active" in vals
+        ):
+            for rec in self:
+                rec.update_intercompany_prices()
         return res
 
     def update_intercompany_prices(self):

--- a/product_supplierinfo_intercompany/models/product_template.py
+++ b/product_supplierinfo_intercompany/models/product_template.py
@@ -66,18 +66,26 @@ class ProductTemplate(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if (
-            "sale_ok" in vals
-            or "purchase_ok" in vals
-            or "list_price" in vals
-            or "standard_price" in vals
-            or "company_id" in vals
-            or "company_ids" in vals
-            or "active" in vals
-        ):
+        if any(field in vals for field in self._fields_for_intercompany_pricelist()):
             for rec in self:
                 rec.update_intercompany_prices()
         return res
+
+    @api.model
+    def _fields_for_intercompany_pricelist(self):
+        """
+        If any of these fields change,
+        the intercompany pricelist will be recomputed
+        """
+        return [
+            "sale_ok",
+            "purchase_ok",
+            "list_price",
+            "standard_price",
+            "company_id",
+            "company_ids",
+            "active",
+        ]
 
     def update_intercompany_prices(self):
         pricelist_ids = (

--- a/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
+++ b/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
@@ -84,6 +84,9 @@ class TestIntercompanySupplierCase(SavepointCase):
         self.assertEqual(len(supplierinfo), 1)
         self.assertEqual(len(supplierinfo.intercompany_pricelist_id), 1)
         self.assertEqual(supplierinfo.price, price)
+        self.assertEqual(
+            supplierinfo.currency_id, supplierinfo.intercompany_pricelist_id.currency_id
+        )
 
 
 class TestIntercompanySupplier(TestIntercompanySupplierCase):
@@ -347,3 +350,11 @@ class TestIntercompanySupplier(TestIntercompanySupplierCase):
         # Select using sudo (as some native odoo code do it)
         supplier = self.product_product_4b.sudo()._select_seller()
         self.assertEqual(supplier.name, partner)
+
+    def test_currency_consistency(self):
+        different_currency = self.env.ref("base.CHF")
+        self.assertNotEqual(self.pricelist_intercompany.currency_id, different_currency)
+        self.pricelist_intercompany.currency_id = different_currency
+        template = self.env["product.template"].create({"name": "New One"})
+        self._add_item(template, 30)
+        self._check_supplier_info_for(template, 30)

--- a/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
+++ b/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
@@ -149,6 +149,14 @@ class TestIntercompanySupplier(TestIntercompanySupplierCase):
         supplierinfo = self._get_supplier_info()
         self.assertEqual(len(supplierinfo), 0)
 
+    def test_archive_pricelist_intercompany(self):
+        self.pricelist_intercompany.active = False
+        supplierinfo = self._get_supplier_info()
+        self.assertEqual(len(supplierinfo), 0)
+        self.pricelist_intercompany.active = True
+        supplierinfo = self._get_supplier_info()
+        self.assertEqual(len(supplierinfo), 4)
+
     def test_intercompany_access_rule(self):
         # Check that supplier this supplier info are not visible
         # with the current user "demo"
@@ -167,6 +175,10 @@ class TestIntercompanySupplier(TestIntercompanySupplierCase):
     def test_add_template_item(self):
         template = self.env.ref("product.product_product_2_product_template")
         self._add_item(template, 30)
+        self._check_supplier_info_for(template, 30)
+        template.active = False
+        self._check_no_supplier_info_for(template)
+        template.active = True
         self._check_supplier_info_for(template, 30)
 
     def test_update_product_item(self):

--- a/product_supplierinfo_intercompany/views/pricelist_views.xml
+++ b/product_supplierinfo_intercompany/views/pricelist_views.xml
@@ -10,6 +10,16 @@
                     attrs="{'invisible': [('company_id', '=', False)]}"
                     groups="base.group_multi_company"
                 />
+                <field
+                    name="intercompany_supplier_lead_time"
+                    attrs="{'invisible': [('is_intercompany_supplier', '=', False)]}"
+                    groups="base.group_multi_company"
+                />
+                <field
+                    name="is_intercompany_supplier"
+                    invisible="1"
+                    groups="!base.group_multi_company"
+                />
             </field>
         </field>
     </record>

--- a/product_supplierinfo_intercompany_multi_company/models/product_intercompany_supplier_mixin.py
+++ b/product_supplierinfo_intercompany_multi_company/models/product_intercompany_supplier_mixin.py
@@ -1,50 +1,24 @@
-from odoo import _, models
-from odoo.exceptions import Warning as UserError
+from odoo import models
 
 
 class ProductIntercompanySupplierMixin(models.AbstractModel):
     _inherit = "product.intercompany.supplier.mixin"
 
-    def _synchronise_supplier_info(self, pricelists=None):
-        # replaced to add company_ids condition
-        if not pricelists:
-            pricelists = self.env["product.pricelist"].search(
-                [("is_intercompany_supplier", "=", True)]
+    def _synchronise_supplier_info_for_record(self, pricelist, supplierinfo):
+        res = super()._synchronise_supplier_info_for_record(pricelist, supplierinfo)
+        if (
+            self._has_intercompany_price(pricelist)
+            and self.company_id == pricelist.company_id
+        ):
+            supplierinfo.sudo().unlink()
+        return res
+
+    def _condition_supplierinfo_create_or_update(self, pricelist, supplierinfo):
+        res = super()._condition_supplierinfo_create_or_update(pricelist, supplierinfo)
+        return res and (
+            not self.company_ids
+            or (
+                pricelist.company_id in self.company_ids
+                and pricelist.company_id != self.company_ids
             )
-        for pricelist in pricelists:
-            if not pricelist.is_intercompany_supplier:
-                raise UserError(
-                    _("The pricelist %s is not intercompany") % pricelist.name
-                )
-            # We pass the pricelist in the context in order to get the right
-            # sale price on record.price (compatible v8 to v12)
-            for record in self.sudo().with_context(
-                pricelist=pricelist.id, automatic_intercompany_sync=True
-            ):
-                domain = record._get_intercompany_supplier_info_domain(pricelist)
-                supplierinfo = record.env["product.supplierinfo"].search(domain)
-                if (
-                    record._has_intercompany_price(pricelist)
-                    and record.sale_ok
-                    and record.purchase_ok
-                    and (
-                        (
-                            pricelist.company_id.id in record.company_ids.ids
-                            and record.company_id.id in record.company_ids.ids
-                        )
-                        or (len(record.company_ids) == 0)
-                    )
-                ):
-                    vals = record._prepare_intercompany_supplier_info(pricelist)
-                    if supplierinfo:
-                        supplierinfo.write(vals)
-                    else:
-                        supplierinfo.create(vals)
-                elif supplierinfo:
-                    supplierinfo.sudo().unlink()
-                if (
-                    record._has_intercompany_price(pricelist)
-                    and pricelist.company_id.id in record.company_ids.ids
-                    and record.company_id.id == pricelist.company_id.id
-                ):
-                    supplierinfo.sudo().unlink()
+        )


### PR DESCRIPTION
These commits

- slightly refactor these two modules so that the method doesn't need to be overwritten
- implement deletion and recreation of supplierinfo when archiving and unarchiving product templates and product pricelists

More details in each commit