### PR TITLE
[14.0][FIX] product_multi_company: variant company related to template company

### DIFF
--- a/product_multi_company/models/product.py
+++ b/product_multi_company/models/product.py
@@ -1,7 +1,7 @@
 # Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ProductProduct(models.Model):
@@ -11,12 +11,5 @@ class ProductProduct(models.Model):
     company_ids = fields.Many2many(
         string="Companies",
         comodel_name="res.company",
-        relation="product_variant_companies_rel",
-        compute="_compute_company_ids",
-        store=True,
+        related="product_tmpl_id.company_ids",
     )
-
-    @api.depends("product_tmpl_id.company_ids")
-    def _compute_company_ids(self):
-        for rec in self:
-            rec.company_ids = [(6, 0, rec.product_tmpl_id.company_ids.ids)]


### PR DESCRIPTION
This PR fixes an issue with the `company_ids` field on `product.product` not being aligned with the same field on the related `product.template`

Issue found while using `purchase_sale_inter_company`: during the automated creation of the SO in company A from the PO in company B, the `company_ids` field on the product template was correct (showing both companies), but the same field on the variant was not (showing only company B), leading to an error due to inconsistent companies (sale order line in company A supposedly had a product from company B. check_company was failing).

Considered other solutions such as `api.depends_context("company")` which also seemed to work, but this seems to simplify while maintaining the same functionality.