### PR TITLE
[FIX] purchase_sale_inter_company: Create sale from other company

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -3,6 +3,8 @@
 # Copyright 2018-2019 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from contextlib import contextmanager
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -68,6 +70,36 @@ class PurchaseOrder(models.Model):
                         % purchase_line.product_id.name
                     )
 
+    @contextmanager
+    def _in_inter_company_env(self, dest_company):
+        """Act as if in `dest_company`."""
+        intercompany_user = dest_company.intercompany_sale_user_id
+        if not intercompany_user:
+            intercompany_user = self.env.user
+
+        self_in_dest_company = (
+            self.with_user(intercompany_user)
+            .sudo()
+            .with_context(
+                allowed_company_ids=[dest_company.id]
+                + [
+                    company.id
+                    for company in intercompany_user.company_ids
+                    if company != dest_company
+                ]
+            )
+        )
+        # The old user with the old company
+        # might have stored in cache values
+        # that with the new user/company
+        # should be not accessible
+        self_in_dest_company.invalidate_cache()
+
+        yield self_in_dest_company
+
+        # Switching back to the old user
+        self.invalidate_cache()
+
     def _inter_company_create_sale_order(self, dest_company):
         """Create a Sale Order from the current PO (self)
         Note : In this method, reading the current PO is done as sudo,
@@ -78,10 +110,6 @@ class PurchaseOrder(models.Model):
         :rtype dest_company : res.company record
         """
         self.ensure_one()
-        # Check intercompany user
-        intercompany_user = dest_company.intercompany_sale_user_id
-        if not intercompany_user:
-            intercompany_user = self.env.user
         # check intercompany product
         self._check_intercompany_product(dest_company)
         # Accessing to selling partner with selling user, so data like
@@ -98,29 +126,27 @@ class PurchaseOrder(models.Model):
                     "purchase price list currency."
                 )
             )
-        # create the SO and generate its lines from the PO lines
-        sale_order_data = self._prepare_sale_order_data(
-            self.name, company_partner, dest_company, self.dest_address_id
-        )
-        sale_order = (
-            self.env["sale.order"]
-            .with_user(intercompany_user.id)
-            .sudo()
-            .create(sale_order_data)
-        )
-        for purchase_line in self.order_line:
-            sale_line_data = self._prepare_sale_order_line_data(
-                purchase_line, dest_company, sale_order
+
+        with self._in_inter_company_env(dest_company) as self_in_dest_company:
+            # create the SO and generate its lines from the PO lines
+            sale_order_data = self_in_dest_company._prepare_sale_order_data(
+                self_in_dest_company.name,
+                company_partner,
+                dest_company,
+                self_in_dest_company.dest_address_id,
             )
-            self.env["sale.order.line"].with_user(intercompany_user.id).sudo().create(
-                sale_line_data
-            )
-        # write supplier reference field on PO
-        if not self.partner_ref:
-            self.partner_ref = sale_order.name
-        # Validation of sale order
-        if dest_company.sale_auto_validation:
-            sale_order.with_user(intercompany_user.id).sudo().action_confirm()
+            sale_order = self_in_dest_company.env["sale.order"].create(sale_order_data)
+            for purchase_line in self_in_dest_company.order_line:
+                sale_line_data = self_in_dest_company._prepare_sale_order_line_data(
+                    purchase_line, dest_company, sale_order
+                )
+                self_in_dest_company.env["sale.order.line"].create(sale_line_data)
+            # write supplier reference field on PO
+            if not self_in_dest_company.partner_ref:
+                self_in_dest_company.partner_ref = sale_order.name
+            # Validation of sale order
+            if dest_company.sale_auto_validation:
+                sale_order.action_confirm()
         return sale_order
 
     def _prepare_sale_order_data(

--- a/purchase_sale_inter_company/models/stock_picking.py
+++ b/purchase_sale_inter_company/models/stock_picking.py
@@ -152,7 +152,9 @@ class StockPicking(models.Model):
         # if the flag is set, block the validation of the picking in the destination company
         if self.env.company.block_po_manual_picking_validation:
             for record in self:
-                dest_company = record.partner_id.commercial_partner_id.ref_company_ids
+                dest_company = (
+                    record.partner_id.commercial_partner_id.sudo().ref_company_ids
+                )
                 if (
                     dest_company and record.picking_type_code == "incoming"
                 ) and record.state in ["done", "waiting", "assigned"]:

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -842,3 +842,43 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             move.quantity_done = move.product_uom_qty
         with self.assertRaises(UserError):
             so_picking_id.button_validate()
+
+    def test_purchase_in_inter_company_env(self):
+        """The context manager `_in_inter_company_env`
+        allows to see the purchase order
+        from another company's point of view.
+        """
+        # Arrange
+        company_a = self.company_a
+        company_a_currency = self.env.ref("base.USD")
+        company_b = self.company_b
+        company_b_currency = self.env.ref("base.EUR")
+
+        purchase = self._create_purchase_order(
+            company_b.partner_id, self.consumable_product
+        )
+        purchase.partner_id.property_purchase_currency_id = company_a_currency
+        # pre-condition
+        self.assertNotEqual(company_a, company_b)
+        self.assertEqual(purchase.env.company, company_a)
+        self.assertEqual(
+            purchase.partner_id.property_purchase_currency_id, company_a_currency
+        )
+
+        # Act
+        # Set a company_dependent field
+        # with a different value for the other company
+        partner_in_company_b = purchase.partner_id.with_company(company_b)
+        partner_in_company_b.property_purchase_currency_id = company_b_currency
+
+        # Assert
+        with purchase._in_inter_company_env(company_b) as purchase_in_company_b:
+            self.assertEqual(
+                purchase_in_company_b.partner_id.property_purchase_currency_id,
+                company_b_currency,
+            )
+
+        self.assertEqual(
+            purchase.partner_id.property_purchase_currency_id,
+            company_a_currency,
+        )


### PR DESCRIPTION
This change fixes the following use case:
1. Install `product_multi_company` and `purchase_sale_inter_company`
2. Create 2 companies: **A** and **B**
4. Configure the companies so that a purchase from **A** triggers a sale from **B**
6. Create a product **Product** and set both companies in its `company_ids`
5. Activate only company **A**
7. Create a purchase in **A** with supplier **B**: it will trigger a sale in **B**
8. Confirm the purchase

**Expected behavior**:
A sale in **B** is created

**Actual behavior**:
Error:
> Companies not compatible
> \<Name of sale order line created in **B**> belongs to company **B** but **Product** belongs to another company

**Additional context**:
I cannot reproduce the issue in runboat, but the automated test (that does not need `product_multi_company`) makes sure that the root cause won't happen again.

The root cause is that the product's `company_ids` is read as only **A** while in a non-sudo environment and stored in cache, even if its real **sudo**ed value is **A**, **B**:
```
>>> product.company_ids
res.company(17,)  # A

>>> product.sudo().company_ids
res.company(17)  # Still A: using sudo does not help

>>> product.invalidate_cache()
None

>>> product.sudo().company_ids
res.company(1, 17)  # A, B

>>> product.company_ids
res.company(1, 17)  # A, B
```