### PR TITLE
[18.0][IMP] account_invoice_inter_company: propagate date to new invoice

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -252,6 +252,7 @@ class AccountMove(models.Model):
             "ref": self.name,
             "payment_reference": self.payment_reference,
             "invoice_date": self.invoice_date,
+            "date": self.date,
             "invoice_origin": _("%(company_name)s - Invoice: %(invoice_name)s")
             % {"company_name": self.company_id.name, "invoice_name": self.name},
             "auto_invoice_id": self.id,

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -488,3 +488,12 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
             [("auto_invoice_id", "=", self.invoice_company_a.id)]
         )
         self.assertFalse(invoices)
+
+    def test_invoice_date(self):
+        self.invoice_company_a.invoice_date = "2025-01-01"
+        self.invoice_company_a.with_user(self.user_company_a.id).action_post()
+        invoices = self.account_move_obj.with_user(self.user_company_b.id).search(
+            [("auto_invoice_id", "=", self.invoice_company_a.id)]
+        )
+        self.assertEqual(invoices.invoice_date.strftime("%Y-%m-%d"), "2025-01-01")
+        self.assertEqual(invoices.date.strftime("%Y-%m-%d"), "2025-01-01")


### PR DESCRIPTION
When creating an invoice with a date earlier than the current date, the invoice generated on the C2 side does not preserve the same date, instead, it recalculates the date and uses the current date. This commit ensures that the created invoice inherits the same date as the original invoice.

FWP of https://github.com/OCA/multi-company/pull/815

TT55902

@Tecnativa @pedrobaeza @victoralmau could you please review this?