### PR TITLE
[17.0][FIX] account_invoice_inter_company: context not cleaned when a destination invoice is created

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -244,7 +244,9 @@ class AccountMove(models.Model):
         :rtype dest_company : res.company record
         """
         self.ensure_one()
-        self = self.with_context(**clean_context(self.env.context))
+        # Remove default_ context keys
+        # pylint: disable=W8121
+        self = self.with_context(clean_context(self.env.context))
         # check if the journal is define in dest company
         self._check_dest_journal(dest_company)
         vals = {


### PR DESCRIPTION
cc @Tecnativa TT58082

If you want remove default_ keys from original context you cannot do a merge context like this
self = self.with_context(**clean_context(self.env.context))

ping @eduezerouali-tecnativa @victoralmau 