### PR TITLE
[16.0][FIX] purchase_sale_stock_inter_company: delivery with lots

### DIFF
--- a/purchase_sale_stock_inter_company/__manifest__.py
+++ b/purchase_sale_stock_inter_company/__manifest__.py
@@ -14,5 +14,5 @@
     "installable": True,
     "auto_install": True,
     "depends": ["purchase_sale_inter_company", "sale_stock", "purchase_stock"],
-    "data": ["views/res_config_view.xml"],
+    "data": ["views/res_config_view.xml", "views/stock_picking_type_views.xml"],
 }

--- a/purchase_sale_stock_inter_company/models/__init__.py
+++ b/purchase_sale_stock_inter_company/models/__init__.py
@@ -2,3 +2,5 @@ from . import purchase_order
 from . import res_company
 from . import res_config
 from . import stock_picking
+from . import stock_production_lot
+from . import stock_picking_type

--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -95,8 +95,10 @@ class StockPicking(models.Model):
                         qty_done = 0.0
                     else:
                         po_move.quantity_done = po_move.product_uom_qty
-                        po_move.lot_ids = product_po_lots[: po_move.product_uom_qty]
-                        product_po_lots = product_po_lots[po_move.product_uom_qty :]
+                        if product_po_lots:
+                            qty = int(po_move.product_uom_qty)
+                            po_move.lot_ids = product_po_lots[:qty]
+                            product_po_lots = product_po_lots[qty:]
                         qty_done -= po_move.product_uom_qty
                     self._check_manual_lots(po_move, product)
                     po_picks |= po_move.picking_id

--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -10,6 +10,9 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     intercompany_picking_id = fields.Many2one(comodel_name="stock.picking")
+    intercompany_create_lots_mode = fields.Selection(
+        related="picking_type_id.intercompany_create_lots_mode"
+    )
 
     def _get_product_intercompany_qty_done_dict(self, sale_move_lines, po_move_lines):
         product = po_move_lines[0].product_id
@@ -17,17 +20,47 @@ class StockPicking(models.Model):
         res = {product: qty_done}
         return res
 
+    def _get_intercompany_move_lots(self, sale_move_lines, po_moves_open, **kwargs):
+        po_move_lots = self.env["stock.lot"]
+        lot_creation_mode = self.intercompany_create_lots_mode
+        if lot_creation_mode == "same":
+            for sale_lot in sale_move_lines.lot_id:
+                po_move_lots |= sale_lot.get_inter_company_lot(
+                    po_moves_open.company_id, **kwargs
+                )
+        elif lot_creation_mode == "manual":
+            po_move_lots |= po_moves_open.mapped("lot_ids")
+        return po_move_lots
+
+    def _check_manual_lots(self, move, product):
+        self.ensure_one()
+        lot_names = move.move_line_ids.mapped("lot_name")
+        lot_ids = move.lot_ids
+        if (
+            self.intercompany_create_lots_mode == "manual"
+            and product.tracking != "none"
+            and move.quantity_done
+            and not lot_names
+            and not lot_ids
+        ):
+            raise UserError(
+                _(
+                    "To validate the delivery, you must first assign lot/serial numbers"
+                    " manually on the receipt of the intercompany purchase."
+                )
+            )
+
     def _set_intercompany_picking_qty(self, purchase):
         po_picks = self.browse()
-        sale_line_ids = self.move_line_ids.mapped("move_id.sale_line_id")
+        sale_line_ids = self.move_line_ids.move_id.sale_line_id
         for sale_line in sale_line_ids:
             sale_move_lines = self.move_line_ids.filtered(
                 lambda ml: ml.move_id.sale_line_id == sale_line
             )
-            po_move_lines = sale_line.auto_purchase_line_id.move_ids.mapped(
-                "move_line_ids"
+            po_moves_open = sale_line.auto_purchase_line_id.move_ids.filtered(
+                lambda sm: sm.state not in ["draft", "done", "cancel"]
             )
-            if not po_move_lines:
+            if not po_moves_open:
                 raise UserError(
                     _(
                         "There's no corresponding line in PO %(po)s for assigning "
@@ -41,23 +74,36 @@ class StockPicking(models.Model):
                         }
                     )
                 )
+            po_moves_open.picking_id.action_assign()
             product_qty_done = self._get_product_intercompany_qty_done_dict(
-                sale_move_lines, po_move_lines
+                sale_move_lines, po_moves_open.move_line_ids
+            )
+            po_move_lots = self._get_intercompany_move_lots(
+                sale_move_lines, po_moves_open
             )
             for product, qty_done in product_qty_done.items():
-                product_po_mls = po_move_lines.filtered(
+                product_po_moves = po_moves_open.filtered(
                     lambda x: x.product_id == product
                 )
-                for po_move_line in product_po_mls:
-                    if po_move_line.reserved_qty >= qty_done:
-                        po_move_line.qty_done = qty_done
+                product_po_lots = po_move_lots.filtered(
+                    lambda x: x.product_id == product
+                )
+                for po_move in product_po_moves:
+                    if po_move.product_uom_qty >= qty_done:
+                        po_move.quantity_done = qty_done
+                        po_move.lot_ids = product_po_lots
                         qty_done = 0.0
-                    elif po_move_line.reserved_qty:
-                        po_move_line.qty_done = po_move_line.reserved_qty
-                        qty_done -= po_move_line.reserved_qty
-                    po_picks |= po_move_line.picking_id
-                if qty_done and product_po_mls:
-                    product_po_mls[-1:].qty_done += qty_done
+                    else:
+                        po_move.quantity_done = po_move.product_uom_qty
+                        po_move.lot_ids = product_po_lots[: po_move.product_uom_qty]
+                        product_po_lots = product_po_lots[po_move.product_uom_qty :]
+                        qty_done -= po_move.product_uom_qty
+                    self._check_manual_lots(po_move, product)
+                    po_picks |= po_move.picking_id
+                if qty_done and product_po_moves:
+                    product_po_moves[-1:].quantity_done += qty_done
+                    product_po_moves[-1:].lot_ids |= product_po_lots
+                    self._check_manual_lots(product_po_moves[-1:], product)
         return po_picks
 
     def _action_done(self):

--- a/purchase_sale_stock_inter_company/models/stock_picking_type.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking_type.py
@@ -1,0 +1,20 @@
+# Copyright 2025 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    intercompany_create_lots_mode = fields.Selection(
+        [("same", "Use Same Number"), ("manual", "Assign Number Manually")],
+        string="Lots Creation Mode in Intercompany",
+        default="same",
+        required=True,
+        help=" Select which logic to follow when a receipt with products "
+        "tracked by Lots/Serial numbers is auto validated by an intercompany flow:\n"
+        "* Use Same Number: Create a Lot/Serial number with the same number as in the "
+        "originating company.\n"
+        "* Assign Number Manually: Assign manually in the receipt the lot number to be used.\n",
+    )

--- a/purchase_sale_stock_inter_company/models/stock_production_lot.py
+++ b/purchase_sale_stock_inter_company/models/stock_production_lot.py
@@ -1,0 +1,44 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# @author Guillaume MASSON <guillaume.masson@groupevoltaire.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockProductionLot(models.Model):
+    _inherit = "stock.lot"
+
+    def _get_inter_company_lot_product(self, **kwargs):
+        """Return the product to use when searching/creating the lot.
+        Hook for customization. By default, it’s just the selling company
+        lot’s product.
+        """
+        self.ensure_one()
+        return self.product_id
+
+    def prepare_inter_company_lot_values(self, company, product):
+        res = {
+            "name": self.name,
+            "product_id": product.id,
+            "company_id": company.id,
+        }
+        if "expiration_date" in self._fields:
+            res.update(expiration_date=self.expiration_date)
+        return res
+
+    def get_inter_company_lot(self, company, **kwargs):
+        self.ensure_one()
+        product = self._get_inter_company_lot_product(**kwargs)
+        lot = self.sudo().search(
+            [
+                ("name", "=", self.name),
+                ("product_id", "=", product.id),
+                ("company_id", "=", company.id),
+            ]
+        )
+        if not lot:
+            lot = self.sudo().create(
+                self.prepare_inter_company_lot_values(company, product)
+            )
+        return lot

--- a/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
+++ b/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
@@ -4,6 +4,8 @@
 # Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
+from odoo.tests import Form
 
 from odoo.addons.purchase_sale_inter_company.tests.test_inter_company_purchase_sale import (
     TestPurchaseSaleInterCompany,
@@ -156,3 +158,123 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
 
         # NEW behavior: matching warehouse must be used
         self.assertEqual(sale.warehouse_id, partner_wh)
+
+    def test_sync_inter_company_picking_qty_with_lot_same_creation_mode(self):
+        self.product.type = "product"
+        self.product.tracking = "serial"
+        self.serial01 = self.env["stock.lot"].create(
+            {
+                "name": "Serial01",
+                "product_id": self.product.id,
+                "company_id": self.company_b.id,
+            }
+        )
+        self.partner_company_b.company_id = False
+        purchase = self.purchase_company_a
+        purchase.order_line.product_qty = 2.0
+        sale = self._approve_po()
+        sale.action_confirm()
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, sale.warehouse_id.lot_stock_id, 1, lot_id=self.serial01
+        )
+        sale_picking = sale.picking_ids[0]
+        sale_picking.picking_type_id.sudo().intercompany_create_lots_mode = "same"
+        sale_picking.sudo().action_confirm()
+        sale_picking.sudo().action_assign()
+        sale_picking.move_ids.quantity_done = 1.0
+        self.assertEqual(sale_picking.move_line_ids.lot_id, self.serial01)
+        res_dict = sale_picking.sudo().button_validate()
+        backorder_wizard = Form(
+            self.env[res_dict["res_model"]].with_context(**res_dict["context"])
+        ).save()
+        backorder_wizard.process()
+        self.assertEqual(purchase.picking_ids[0].move_line_ids.qty_done, 1)
+        self.assertEqual(
+            purchase.picking_ids[0].move_line_ids.lot_id.name, self.serial01.name
+        )
+        self.assertEqual(purchase.picking_ids[1].move_line_ids.qty_done, 0)
+        self.assertEqual(purchase.order_line.qty_received, 1)
+
+    def test_sync_inter_company_picking_qty_with_lot_manual_mode_success(self):
+        self.product.type = "product"
+        self.product.tracking = "serial"
+        self.serial01 = self.env["stock.lot"].create(
+            {
+                "name": "Serial01",
+                "product_id": self.product.id,
+                "company_id": self.company_b.id,
+            }
+        )
+        self.serial02 = self.env["stock.lot"].create(
+            {
+                "name": "Serial02",
+                "product_id": self.product.id,
+                "company_id": self.company_a.id,
+            }
+        )
+        self.partner_company_b.company_id = False
+        purchase = self.purchase_company_a
+        purchase.order_line.product_qty = 2.0
+        sale = self._approve_po()
+        sale.action_confirm()
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, sale.warehouse_id.lot_stock_id, 1, lot_id=self.serial01
+        )
+        sale_picking = sale.picking_ids[0]
+        sale_picking.picking_type_id.sudo().intercompany_create_lots_mode = "manual"
+        sale_picking.sudo().action_confirm()
+        sale_picking.sudo().action_assign()
+        sale_picking.move_ids.quantity_done = 1.0
+        self.assertEqual(sale_picking.move_line_ids.lot_id, self.serial01)
+
+        purchase.picking_ids[0].move_ids[0].lot_ids = [(4, self.serial02.id)]
+
+        res_dict = sale_picking.sudo().button_validate()
+        backorder_wizard = Form(
+            self.env[res_dict["res_model"]].with_context(**res_dict["context"])
+        ).save()
+        backorder_wizard.process()
+        self.assertEqual(purchase.picking_ids[0].move_line_ids.qty_done, 1)
+        self.assertEqual(
+            purchase.picking_ids[0].move_line_ids.lot_id.name, self.serial02.name
+        )
+        self.assertEqual(purchase.picking_ids[1].move_line_ids.qty_done, 0)
+        self.assertEqual(purchase.order_line.qty_received, 1)
+
+    def test_sync_inter_company_picking_qty_with_lot_manual_mode_error(self):
+        self.product.type = "product"
+        self.product.tracking = "serial"
+        self.serial01 = self.env["stock.lot"].create(
+            {
+                "name": "Serial01",
+                "product_id": self.product.id,
+                "company_id": self.company_b.id,
+            }
+        )
+        self.serial02 = self.env["stock.lot"].create(
+            {
+                "name": "Serial02",
+                "product_id": self.product.id,
+                "company_id": self.company_a.id,
+            }
+        )
+        self.partner_company_b.company_id = False
+        purchase = self.purchase_company_a
+        purchase.order_line.product_qty = 2.0
+        sale = self._approve_po()
+        sale.action_confirm()
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, sale.warehouse_id.lot_stock_id, 1, lot_id=self.serial01
+        )
+        sale_picking = sale.picking_ids[0]
+        sale_picking.picking_type_id.sudo().intercompany_create_lots_mode = "manual"
+        sale_picking.sudo().action_confirm()
+        sale_picking.sudo().action_assign()
+        sale_picking.move_ids.quantity_done = 1.0
+        self.assertEqual(sale_picking.move_line_ids.lot_id, self.serial01)
+        res_dict = sale_picking.sudo().button_validate()
+        backorder_wizard = Form(
+            self.env[res_dict["res_model"]].with_context(**res_dict["context"])
+        ).save()
+        with self.assertRaises(UserError):
+            backorder_wizard.process()

--- a/purchase_sale_stock_inter_company/views/stock_picking_type_views.xml
+++ b/purchase_sale_stock_inter_company/views/stock_picking_type_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_type_form_intercompany_lot_mode" model="ir.ui.view">
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <field name="use_existing_lots" position="after">
+                <field
+                    name="intercompany_create_lots_mode"
+                    attrs="{'invisible': [('code','!=','outgoing')]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Supersedes PR https://github.com/OCA/multi-company/pull/842 to add the possibility to decide how the lot should be created in the intercompany receipt. 

Also it makes the code more flexible to allow customization in inheritance.