### PR TITLE
[16.0][FIX] partner_multi_company: Keep partner companies aligned

### DIFF
--- a/partner_multi_company/README.rst
+++ b/partner_multi_company/README.rst
@@ -85,6 +85,9 @@ Contributors
   * Vicent Cubells <vicent.cubells@tecnativa.com>
 
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/partner_multi_company/models/__init__.py
+++ b/partner_multi_company/models/__init__.py
@@ -1,2 +1,3 @@
+from . import res_company
 from . import res_partner
 from . import res_users

--- a/partner_multi_company/models/res_company.py
+++ b/partner_multi_company/models/res_company.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Simone Rubino - PyTech
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        companies = super().create(vals_list)
+        # The new company is added to the user
+        # but that does not trigger the user's write
+        # that would align the partner's companies,
+        # so we have to do it explicitly
+        for company in companies:
+            for user in company.user_ids:
+                # If the partner has no companies,
+                # it means it already accepts all the companies
+                # so there is no need to add the new one
+                if user.partner_id.company_ids:
+                    user.partner_id.company_ids += company
+        return companies

--- a/partner_multi_company/models/res_users.py
+++ b/partner_multi_company/models/res_users.py
@@ -9,10 +9,13 @@ class ResUsers(models.Model):
 
     @api.model_create_multi
     def create(self, vals):
-        res = super(ResUsers, self).create(vals)
-        if "company_ids" in vals:
-            res.partner_id.company_ids = vals["company_ids"]
-        return res
+        users = super(ResUsers, self).create(vals)
+        for user in users:
+            # The new user might have a company even if it was not in `vals`
+            # because of defaults for example.
+            if user.company_ids:
+                user.partner_id.company_ids += user.company_ids
+        return users
 
     def write(self, vals):
         res = super(ResUsers, self.with_context(from_res_users=True)).write(vals)

--- a/partner_multi_company/models/res_users.py
+++ b/partner_multi_company/models/res_users.py
@@ -18,7 +18,6 @@ class ResUsers(models.Model):
         return users
 
     def write(self, vals):
-        res = super(ResUsers, self.with_context(from_res_users=True)).write(vals)
         if "company_ids" in vals:
             for user in self.sudo():
                 new_company_ids = []
@@ -41,4 +40,4 @@ class ResUsers(models.Model):
             for user in self.sudo():
                 if user.partner_id.company_ids:
                     user.partner_id.company_ids = [(4, vals["company_id"])]
-        return res
+        return super(ResUsers, self.with_context(from_res_users=True)).write(vals)

--- a/partner_multi_company/readme/CONTRIBUTORS.rst
+++ b/partner_multi_company/readme/CONTRIBUTORS.rst
@@ -6,3 +6,6 @@
   * Vicent Cubells <vicent.cubells@tecnativa.com>
 
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/partner_multi_company/static/description/index.html
+++ b/partner_multi_company/static/description/index.html
@@ -433,6 +433,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Kitti Upariphutthiphong &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo.exceptions import AccessError
-from odoo.tests import common, tagged
+from odoo.tests import common, new_test_user, tagged
 
 
 @tagged("post_install", "-at_install")
@@ -181,3 +181,10 @@ class TestPartnerMultiCompany(common.TransactionCase):
         )
         self.assertIn(company, admin_user.company_ids)
         self.assertIn(company, admin_user.partner_id.company_ids)
+
+    def test_new_user_partner_company(self):
+        """When creating a new user, its partner has all the user's companies."""
+        new_user = new_test_user(self.env, login="test_new_user_partner_company")
+        companies = new_user.company_ids
+        self.assertTrue(companies)
+        self.assertIn(companies, new_user.partner_id.company_ids)

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -166,3 +166,18 @@ class TestPartnerMultiCompany(common.TransactionCase):
             self.partner_company_none.with_user(self.user_company_1).read(["name"]),
             [{"id": self.partner_company_none.id, "name": "partner without company"}],
         )
+
+    def test_company_creation_with_users(self):
+        """When creating a new company with users,
+        the users and their partners are linked to the new company."""
+        admin_user = self.env.ref("base.user_admin")
+        company = self.env["res.company"].create(
+            {
+                "name": "Test company creation with users",
+                "user_ids": [
+                    (4, admin_user.id),
+                ],
+            }
+        )
+        self.assertIn(company, admin_user.company_ids)
+        self.assertIn(company, admin_user.partner_id.company_ids)

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -188,3 +188,15 @@ class TestPartnerMultiCompany(common.TransactionCase):
         companies = new_user.company_ids
         self.assertTrue(companies)
         self.assertIn(companies, new_user.partner_id.company_ids)
+
+    def test_assign_user_multi_companies(self):
+        """Multiple companies are assigned to the user,
+        check that partner companies are aligned."""
+        new_user = new_test_user(self.env, login="test_assign_user_multi_companies")
+        new_user.write(
+            {
+                "company_id": self.company_1.id,
+                "company_ids": [(4, self.company_1.id), (4, self.company_2.id)],
+            }
+        )
+        self.assertEqual(new_user.company_ids, new_user.partner_id.company_ids)


### PR DESCRIPTION
**Steps**:
1. In an empty DB with demo data install `l10n_it`, `partner_multi_company`, `stock`

**Actual Behavior**:
```
2025-10-06 10:55:13,769 1 WARNING ? odoo.modules.loading: Module l10n_it demo data failed to install, installed without demo data 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/[loading.py](https://loading.py/)", line 91, in load_demo
    load_data(cr, idref, mode, kind='demo', package=package)
  File "/opt/odoo/custom/src/odoo/odoo/modules/[loading.py](https://loading.py/)", line 73, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/custom/src/odoo/odoo/tools/[convert.py](https://convert.py/)", line 771, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/custom/src/odoo/odoo/tools/[convert.py](https://convert.py/)", line 837, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/custom/src/odoo/odoo/tools/[convert.py](https://convert.py/)", line 757, in parse
    self._tag_root(de)
  File "/opt/odoo/custom/src/odoo/odoo/tools/[convert.py](https://convert.py/)", line 717, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/l10n_it/demo/demo_company.xml:25
The partner must have at least all the companies associated with the user.
View error context:
'-no context-'
```

**Expected behavior**:
Demo data of `l10n_it` is loaded

**Additional context**:
This happens because `stock` creates a new company with admin user (see https://github.com/odoo/odoo/blob/5a991ffaf50d3a12d628bd70e6b2f2c9eb912d84/addons/stock/data/stock_demo.xml#L161), but the field `res.users.company_ids` is only updated at cache level (in https://github.com/odoo/odoo/blob/5a991ffaf50d3a12d628bd70e6b2f2c9eb912d84/odoo/fields.py#L4907) so `res.users.write` is not called so the new company is not added to the partner's companies as it happens when writing to `res.users.company_ids`.

The following `write` on `res.users.company_ids` done by `l10n_it`'s demo data (in https://github.com/odoo/odoo/blob/5a991ffaf50d3a12d628bd70e6b2f2c9eb912d84/addons/l10n_it/demo/demo_company.xml#L27) triggers the validation of the field so the constraint raises a `ValidationErrorì that is downgraded to a WARNING because it's just demo data.

The same happens on write to `res.company.user_ids` but that is way less common because the field is not even shown in the UI.

I believe this is an edge case missed by https://github.com/OCA/multi-company/pull/670 so people involved there might be interested @ArnauCForgeFlow @LoisRForgeFlow @pedrobaeza please let me know what you think.