### PR TITLE
[16.0][FIX] purchase_sale_stock_inter_company

### DIFF
--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -72,6 +72,12 @@ class StockPicking(models.Model):
             purchase.picking_ids.write({"intercompany_picking_id": pick.id})
             po_picks |= pick._set_intercompany_picking_qty(purchase)
         # Transfer dropship pickings
-        for po_pick in po_picks.sudo():
-            po_pick.with_company(po_pick.company_id.id)._action_done()
+        pending_picks = po_picks.filtered(lambda p: p.state not in ("done", "cancel"))
+
+        for po_pick in pending_picks.sudo():
+            po_pick.with_context(
+                skip_backorder=True,
+                skip_immediate=True,
+                bypass_set_number_of_packages=True,
+            ).with_company(po_pick.company_id.id).button_validate()
         return super()._action_done()


### PR DESCRIPTION
Problem:
In intercompany scenarios with partial deliveries from different warehouses, automatic validation fails. For instance when Company A purchases 2 units from Company B, and Company B delivers via two separate 1-unit pickings:

First delivery validates correctly but remaining quantity gets cancelled instead of creating a backorder
Second delivery fails with "No corresponding line in PO" because the purchase order line was cancelled
Manual validation works correctly, but automatic validation doesn't respect backorder configuration

Root Cause:
The _set_intercompany_picking_qty() method returns all pickings related to the purchase order, including already completed pickings from previous partial deliveries. When processing backorders, the system attempts to validate these completed pickings, causing validation failures.

Changes Made:
Changed from _action_done() to button_validate() to respect user backorder configuration instead of always canceling remaining quantities
Added picking state filtering: Filter out completed/cancelled pickings before validation to prevent attempts to validate already processed transfers

Impact:
Fixes intercompany partial deliveries with backorders
Respects user backorder settings (Create/Ask/Never)
Maintains backward compatibility for single deliveries