### PR TITLE
[18.0][FIX] product_multi_company_stock: typo in manifest

### DIFF
--- a/product_multi_company_stock/__manifest__.py
+++ b/product_multi_company_stock/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Product multi-company Stock",
     "summary": "Does not allow to remove company if there is stock or moves "
     "in that company",
-    "author": "ForgeFLow," "Odoo Community Association (OCA)",
+    "author": "ForgeFlow," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/multi-company",
     "category": "Product Management",
     "version": "18.0.1.0.0",


### PR DESCRIPTION
Typo.