### PR TITLE
[18.0][IMP] utm_source_multi_company: test coverage

### DIFF
--- a/utm_source_multi_company/tests/__init__.py
+++ b/utm_source_multi_company/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_utm_source

--- a/utm_source_multi_company/tests/test_utm_source.py
+++ b/utm_source_multi_company/tests/test_utm_source.py
@@ -1,0 +1,18 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests import TransactionCase
+
+
+class TestUtmSource(TransactionCase):
+    def test_unique_name_constraint(self):
+        company = self.env["res.company"].create({"name": "test"})
+        old = self.env.ref("utm.utm_source_search_engine")
+        new = self.env["utm.source"].create(
+            {"name": old.name, "company_id": company.id}
+        )
+        self.assertNotEqual(
+            old.name, new.name, "should be changed by utm.mixin _get_unique_names"
+        )
+        new.name = old.name
+        self.assertEqual(
+            old.name, new.name, "should be allowed by modified _sql_constraints"
+        )


### PR DESCRIPTION
The `utm.source` `create` method renames records such that the constraint can only be tested with `write`.