### PR TITLE
[16.0][FIX] partner_multi_company: Fixed wrong usage of create function

### DIFF
--- a/partner_multi_company/models/res_users.py
+++ b/partner_multi_company/models/res_users.py
@@ -8,8 +8,8 @@ class ResUsers(models.Model):
     _inherit = "res.users"
 
     @api.model_create_multi
-    def create(self, vals):
-        users = super(ResUsers, self).create(vals)
+    def create(self, vals_list):
+        users = super(ResUsers, self).create(vals_list)
         for user in users:
             # The new user might have a company even if it was not in `vals`
             # because of defaults for example.


### PR DESCRIPTION
Using the wrong parameter in create function leads to, that for res.partner all create-functions called with parameter "vals_list" will break.

TypeError: Base.create() got an unexpected keyword argument 'vals_list'