### PR TITLE
[18.0][IMP] purchase_sale_stock_inter_company: prevent errors when stock_picking_batch is installed

### DIFF
--- a/purchase_sale_stock_inter_company/models/purchase_order.py
+++ b/purchase_sale_stock_inter_company/models/purchase_order.py
@@ -31,3 +31,16 @@ class PurchaseOrder(models.Model):
         if warehouse:
             new_order.update({"warehouse_id": warehouse.id})
         return new_order
+
+    def _inter_company_create_sale_order(self, dest_company):
+        res = super()._inter_company_create_sale_order(dest_company)
+        # Invalidate the computed field to force its recomputation.
+        # When `stock_picking_batch` is installed,
+        # the picking state is used in many places, so it is computed and cached.
+        # At this point, however, it is not recomputed automatically.
+        # Since the sale order is created after the picking,
+        # these fields are not updated automatically.
+        # We therefore trigger a manual recomputation to ensure consistency.
+        self.invalidate_recordset(["intercompany_sale_order_id"])
+        self.picking_ids._compute_state()
+        return res

--- a/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
+++ b/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
@@ -16,6 +16,17 @@ TestPurchaseSaleInterCompany = test_icps.TestPurchaseSaleInterCompany
 
 class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
     @classmethod
+    def _configure_user(cls, user):
+        res = super()._configure_user(user)
+        # Add stock user group to the user
+        # to prevent access errors during tests
+        # When `stock_picking_batch` is installed,
+        # the model stock.picking.batch
+        # has access rights that restrict access to the group_stock_user
+        user.groups_id |= cls.env.ref("stock.group_stock_user")
+        return res
+
+    @classmethod
     def _create_warehouse(cls, code, company):
         address = cls.env["res.partner"].create({"name": f"{code} address"})
         return cls.env["stock.warehouse"].create(


### PR DESCRIPTION
- Force recomputation of the picking state based on the field `intercompany_sale_order_id`, which is set after the picking is created.
- Add the stock.group_stock_user group to the user to ensure proper access rights.
<img width="1146" height="418" alt="image" src="https://github.com/user-attachments/assets/9413857a-9010-4a44-ba35-ad051998784b" />

Before this commit, the picking state was `assigned`, but in the reception at the other company, the expected state should have been `waiting`. The field was not recomputed because the `intercompany_sale_order_id` field in `purchase.order` was not triggering a recomputation.

TT56365
@Tecnativa @pilarvargas-tecnativa @pedrobaeza @sergio-teruel  could you please review this?