### PR TITLE
[18.0][FIX] purchase_sale_inter_company: avoid multicompany issues when the sale order is created and confirmed

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -37,8 +37,8 @@ class PurchaseOrder(models.Model):
                 purchase_order.partner_id.commercial_partner_id.ref_company_ids
             )
             if dest_company and dest_company.so_from_po:
-                purchase_order.with_company(
-                    dest_company.id
+                purchase_order.with_context(
+                    allowed_company_ids=dest_company.ids
                 )._inter_company_create_sale_order(dest_company)
         return res
 
@@ -111,7 +111,7 @@ class PurchaseOrder(models.Model):
             self.partner_ref = sale_order.name
         # Validation of sale order
         if dest_company.sale_auto_validation:
-            sale_order.with_user(intercompany_user.id).sudo().action_confirm()
+            sale_order.with_user(intercompany_user.id).action_confirm()
         return sale_order
 
     def _prepare_sale_order_data(

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -76,6 +76,7 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         # Configure User
         cls._configure_user(cls.user_company_a)
         cls._configure_user(cls.user_company_b)
+        cls._configure_user(cls.intercompany_sale_user_id)
 
         # Create purchase order
         cls.purchase_company_a = cls._create_purchase_order(cls.partner_company_b)


### PR DESCRIPTION

Install the `purchase_sale_stock_inter_company` module

Configuration in the companies:
- Sync pickings
- Auto-validate the sale order

<img width="495" height="480" alt="image" src="https://github.com/user-attachments/assets/da762e69-bf5c-49f5-a18a-642499080438" />

Enable Dropshipping and Multi-Step Routes in the inventory settings. In the Dropship route, set Company A.
In the Buy route, set Company B.

<img width="1554" height="133" alt="image" src="https://github.com/user-attachments/assets/839f0694-09ff-4a58-b1f6-9e04166caf9b" />

Create a product and, in Company A, enable only the `Dropshipping` route. Set the supplier info with the partner of `Company B`, but do not set another supplier info for Company B (because this product should not automatically generate a purchase in Company B).

<img width="1204" height="321" alt="image" src="https://github.com/user-attachments/assets/eda15314-a297-4c4d-acb8-44503cf11129" />

Create a sale order with any customer, confirm it, and go to the generated purchase order. Try to confirm the purchase order, an error will be displayed:

“There is no matching vendor price to generate the purchase order for this product.”
<img width="1552" height="748" alt="image" src="https://github.com/user-attachments/assets/95509579-c7ab-4d58-99ba-92fe13413bc8" />


This happens because the sale order in Company B is confirmed automatically, and the code executes with `sudo`, meaning **record rules are not applied**. As a result, the Dropship route is considered, although in this case it should be ignored.

After this commit, record rules are correctly applied, and routes are taken into account according to the record rules for the current company.

TT56365
@Tecnativa @pedrobaeza @sergio-teruel @christian-ramos-tecnativa @metaminux could you please review this?