### PR TITLE
[12.0][IMP] purchase_sale_inter_company: make move deletion overridable

### DIFF
--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -45,6 +45,10 @@ class SaleOrder(models.Model):
                 _('Error. The following lines do not match on'
                   ' the remote order: %s') % "\n".join(unequal_line))
 
+    @api.model
+    def delete_purchase_moves(self, purchase_moves):
+        purchase_moves.unlink()
+
     @api.multi
     def action_confirm(self):
         for order in self.filtered('auto_purchase_order_id'):
@@ -155,7 +159,7 @@ class SaleOrder(models.Model):
                         new_pickings |= new_pick
                     purchase_move_lines.unlink()
                     purchase_moves._action_cancel()
-                    purchase_moves.unlink()
+                    sale_order.delete_purchase_moves(purchase_moves)
                     purchase_picking._update_extra_data_in_picking(pickings[:1])
                     new_pickings.action_assign()
 

--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -49,6 +49,106 @@ class SaleOrder(models.Model):
     def delete_purchase_moves(self, purchase_moves):
         purchase_moves.unlink()
 
+    def _sync_split_purchase_picking(
+        self, sale_order, pickings, purchase_picking, po_company
+    ):
+        """Split a single purchase receipt into N receipts to mirror N sale
+        deliveries.  Extracted so subclasses can override the split strategy
+        (e.g. use write() instead of copy()+cancel()+delete()).
+        """
+        purchase_moves = purchase_picking.move_ids_without_package
+        purchase_move_lines = purchase_picking.move_line_ids_without_package
+        new_pickings = self.env["stock.picking"].sudo(
+            po_company.intercompany_user_id.id
+        )
+        for i, pick in enumerate(pickings):
+            moves = pick.move_ids_without_package
+            new_moves = self.env["stock.move"].sudo(
+                po_company.intercompany_user_id.id
+            )
+            new_move_lines = self.env["stock.move.line"].sudo(
+                po_company.intercompany_user_id.id
+            )
+            for move in moves:
+                purchase_move = purchase_moves.filtered(
+                    lambda m: m.product_id.id == move.product_id.id
+                )[:1]
+                new_move = purchase_move.sudo(
+                    po_company.intercompany_user_id.id
+                ).copy(
+                    {
+                        "picking_id": purchase_picking.id if i == 0 else False,
+                        "name": move.name,
+                        "product_uom_qty": move.product_uom_qty,
+                        "product_uom": move.product_uom.id,
+                        "price_unit": -move.price_unit,
+                        "note": move.note,
+                        "create_date": move.create_date,
+                        "date": move.date,
+                        "date_expected": move.date_expected,
+                        "state": move.state,
+                    }
+                )
+                new_move._update_extra_data_in_move(move)
+                new_moves |= new_move
+                for move_line in move.move_line_ids.filtered(
+                    lambda l: l.package_level_id
+                    and not l.picking_type_entire_packs
+                ):
+                    purchase_move_line = purchase_move_lines.filtered(
+                        lambda l: l.product_id.id == move_line.product_id.id
+                    )[:1]
+                    new_move_line = purchase_move_line.sudo(
+                        po_company.intercompany_user_id.id
+                    ).copy(
+                        {
+                            "picking_id": purchase_picking.id if i == 0 else False,
+                            "move_id": new_move.id,
+                            "product_uom_qty": move_line.product_uom_qty,
+                            "product_uom_id": move_line.product_uom_id.id,
+                            "create_date": move_line.create_date,
+                            "date": move_line.date,
+                            "state": move_line.state,
+                        }
+                    )
+                    new_move_line._update_extra_data_in_move_line(move_line)
+                    new_move_lines |= new_move_line
+            if i == 0:
+                purchase_picking.sudo(
+                    purchase_picking.company_id.intercompany_user_id.id
+                ).write(
+                    {
+                        "intercompany_picking_id": pick.id,
+                        "note": pick.note,
+                        "create_date": pick.create_date,
+                        "state": pick.state,
+                    }
+                )
+                new_pick = purchase_picking
+            else:
+                new_pick = purchase_picking.sudo(
+                    po_company.intercompany_user_id.id
+                ).copy(
+                    {
+                        "move_ids_without_package": [(6, False, new_moves.ids)],
+                        "move_line_ids_without_package": [
+                            (6, False, new_move_lines.ids)
+                        ],
+                        "intercompany_picking_id": pick.id,
+                        "note": pick.note,
+                        "create_date": pick.create_date,
+                        "state": pick.state,
+                    }
+                )
+                new_pick._update_extra_data_in_picking(pick)
+            pick.write({"intercompany_picking_id": new_pick.id})
+            new_pickings |= new_pick
+        purchase_move_lines.unlink()
+        purchase_moves._action_cancel()
+        sale_order.delete_purchase_moves(purchase_moves)
+        purchase_picking._update_extra_data_in_picking(pickings[:1])
+        new_pickings.action_assign()
+
     @api.multi
     def action_confirm(self):
         for order in self.filtered('auto_purchase_order_id'):
@@ -81,87 +181,12 @@ class SaleOrder(models.Model):
                     pickings.write({'intercompany_picking_id': purchase_picking.id})
                 if len(pickings) > 1 and len(purchase_picking) == 1:
                     # If there are several pickings in the sale order and one
-                    # in the purchase order, then split the receipt
-                    # thus we need to recreate new moves and moves lines, as they differ
-                    purchase_moves = purchase_picking.move_ids_without_package
-                    purchase_move_lines = purchase_picking.move_line_ids_without_package
-                    new_pickings = self.env["stock.picking"].sudo(
-                        po_company.intercompany_user_id.id)
-                    for i, pick in enumerate(pickings):
-                        moves = pick.move_ids_without_package
-                        new_moves = self.env["stock.move"].sudo(
-                            po_company.intercompany_user_id.id)
-                        new_move_lines = self.env["stock.move.line"].sudo(
-                            po_company.intercompany_user_id.id)
-                        for move in moves:
-                            purchase_move = purchase_moves.filtered(
-                                lambda m: m.product_id.id == move.product_id.id)
-                            new_move = purchase_move.sudo(
-                                po_company.intercompany_user_id.id).copy({
-                                    'picking_id':
-                                        purchase_picking.id if i == 0 else False,
-                                    "name": move.name,
-                                    "product_uom_qty": move.product_uom_qty,
-                                    "product_uom": move.product_uom.id,
-                                    "price_unit": -move.price_unit,
-                                    "note": move.note,
-                                    "create_date": move.create_date,
-                                    "date": move.date,
-                                    "date_expected": move.date_expected,
-                                    "state": move.state,
-                                })
-                            new_move._update_extra_data_in_move(move)
-                            new_moves |= new_move
-                            for move_line in move.move_line_ids.filtered(
-                                lambda l: l.package_level_id and
-                                not l.picking_type_entire_packs
-                            ):
-                                purchase_move_line = purchase_move_lines.filtered(
-                                    lambda l:
-                                    l.product_id.id == move_line.product_id.id)[:1]
-                                new_move_line = purchase_move_line.sudo(
-                                    po_company.intercompany_user_id.id).copy({
-                                        'picking_id': purchase_picking.id
-                                        if i == 0 else False,
-                                        'move_id': new_move.id,
-                                        "product_uom_qty": move_line.product_uom_qty,
-                                        "product_uom_id": move_line.product_uom_id.id,
-                                        "create_date": move_line.create_date,
-                                        "date": move_line.date,
-                                        "state": move_line.state,
-                                    })
-                                new_move_line._update_extra_data_in_move_line(move_line)
-                                new_move_lines |= new_move_line
-                        if i == 0:
-                            purchase_picking.sudo(
-                                purchase_picking.company_id.intercompany_user_id.id
-                            ).write({
-                                'intercompany_picking_id': pick.id,
-                                'note': pick.note,
-                                "create_date": pick.create_date,
-                                "state": pick.state,
-                            })
-                            new_pick = purchase_picking
-                        else:
-                            new_pick = purchase_picking.sudo(
-                                po_company.intercompany_user_id.id).copy({
-                                    'move_ids_without_package': [
-                                        (6, False, new_moves.ids)],
-                                    'move_line_ids_without_package': [
-                                        (6, False, new_move_lines.ids)],
-                                    'intercompany_picking_id': pick.id,
-                                    'note': pick.note,
-                                    "create_date": pick.create_date,
-                                    "state": pick.state,
-                                })
-                            new_pick._update_extra_data_in_picking(pick)
-                        pick.write({'intercompany_picking_id': new_pick.id})
-                        new_pickings |= new_pick
-                    purchase_move_lines.unlink()
-                    purchase_moves._action_cancel()
-                    sale_order.delete_purchase_moves(purchase_moves)
-                    purchase_picking._update_extra_data_in_picking(pickings[:1])
-                    new_pickings.action_assign()
+                    # in the purchase order, then split the receipt.
+                    # Delegated to _sync_split_purchase_picking so subclasses
+                    # can override the split strategy.
+                    sale_order._sync_split_purchase_picking(
+                        sale_order, pickings, purchase_picking, po_company
+                    )
 
         return res
 


### PR DESCRIPTION
After https://github.com/OCA/multi-company/pull/508

We can experience slow performance when confirming intercompany orders

## Proposal
Do not unlink the original stock move of the purchase order to improve action_confirm performance
