### PR TITLE
[18.0][FIX] base_multi_company: 'company_id' use all common companies

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -22,23 +22,30 @@ class MultiCompanyAbstract(models.AbstractModel):
     )
 
     @api.depends("company_ids")
-    @api.depends_context("company", "_check_company_source_id")
+    @api.depends_context("companies", "company", "_check_company_source_id")
     def _compute_company_id(self):
         for record in self:
             # Set this priority computing the company (if included in the allowed ones)
             # for avoiding multi company incompatibility errors:
             # - If this call is done from method _check_company, the company of the
             #   record to be compared.
-            # - Otherwise, current company of the user.
-            company_id = (
-                self.env.context.get("_check_company_source_id")
-                or self.env.context.get("force_company")
-                or self.env.company.id
-            )
+            # - Otherwise, use current companies of the user, prioritizing main company.
+            # - As last resource, use the first allowed company.
+            company_id = self.env.context.get(
+                "_check_company_source_id"
+            ) or self.env.context.get("force_company")
             if company_id in record.company_ids.ids:
                 record.company_id = company_id
             else:
-                record.company_id = record.company_ids[:1].id
+                common_companies = self.env.companies & record.company_ids
+                # Prioritize main company
+                if common_companies and (self.env.company in common_companies):
+                    record.company_id = self.env.company.id
+                # Or use the first common company
+                elif common_companies:
+                    record.company_id = common_companies[0].id
+                else:  # Use the fallback as last resource
+                    record.company_id = record.company_ids[:1].id
 
     def _inverse_company_id(self):
         # To allow modifying allowed companies by non-aware base_multi_company

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -156,16 +156,32 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         for company in user.company_ids:
             user.write({"company_id": company.id})
             # Force recompute
-            tester.invalidate_model()
+            tester.invalidate_model(["company_id"])
             # Ensure that the current user is on the right company
             self.assertEqual(user.company_id, company)
             self.assertEqual(tester.company_id, company)
             # So can read company fields without Access error
             self.assertTrue(bool(tester.company_id.name))
+        # If current main company of the user does not match with the record's
+        # company_ids then one of the common companies between the two should be set
+        user_companies = company1 + company3
+        user.write(
+            {
+                "company_id": company1.id,
+                "company_ids": [(6, False, user_companies.ids)],
+            }
+        )
+        companies = company2 + company3
+        tester.write({"company_ids": [(6, False, companies.ids)]})
+        # Force recompute
+        tester.invalidate_model(["company_id"])
+        self.assertFalse(tester.company_ids <= user.company_ids)  # Is not subset
+        self.assertNotEqual(tester.company_id.id, user.company_id.id)
+        self.assertIn(tester.company_id.id, user.company_ids.ids)
         # Switch to a company not in tester.company_ids
         self.switch_user_company(user, company4)
         # Force recompute
-        tester.invalidate_model()
+        tester.invalidate_model(["company_id"])
         self.assertNotEqual(user.company_id.id, tester.company_ids.ids)
         self.assertTrue(bool(tester.company_id.id))
         self.assertTrue(bool(tester.company_id.name))


### PR DESCRIPTION
Before this commit, we could have wrong access errors on records. As an example, if we had a user with enabled companies A and C (being A the main company) and a record with enabled companies B and C, we would get and access error. 

That's because the `company_id` for the record was set to B (since it did not match with the user's main company, A, it took the first of the enabled companies for the record). But it should be set to C, because it's the first common company between the user and the record, and that would allow us to access the record without any error. Also added new use cases in the testing to check this behavior. Without the code changes in the commit, the test fails.