### PR TITLE
[18.0][FIX] base_multi_company: clean cache _compute_company_id

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
+from odoo.exceptions import AccessError
 
 
 class MultiCompanyAbstract(models.AbstractModel):
@@ -25,6 +26,11 @@ class MultiCompanyAbstract(models.AbstractModel):
     @api.depends_context("companies", "company", "_check_company_source_id")
     def _compute_company_id(self):
         for record in self:
+            try:  # Try to read cached value
+                companies = record.company_ids
+            except AccessError:  # Clear cache and retry
+                record.invalidate_recordset(["company_ids"])
+                companies = record.company_ids
             # Set this priority computing the company (if included in the allowed ones)
             # for avoiding multi company incompatibility errors:
             # - If this call is done from method _check_company, the company of the
@@ -34,10 +40,10 @@ class MultiCompanyAbstract(models.AbstractModel):
             company_id = self.env.context.get(
                 "_check_company_source_id"
             ) or self.env.context.get("force_company")
-            if company_id in record.company_ids.ids:
+            if company_id in companies.ids:
                 record.company_id = company_id
             else:
-                common_companies = self.env.companies & record.company_ids
+                common_companies = self.env.companies & companies
                 # Prioritize main company
                 if common_companies and (self.env.company in common_companies):
                     record.company_id = self.env.company.id
@@ -45,7 +51,7 @@ class MultiCompanyAbstract(models.AbstractModel):
                 elif common_companies:
                     record.company_id = common_companies[0].id
                 else:  # Use the fallback as last resource
-                    record.company_id = record.company_ids[:1].id
+                    record.company_id = companies[:1].id
 
     def _inverse_company_id(self):
         # To allow modifying allowed companies by non-aware base_multi_company


### PR DESCRIPTION
This error solves the issue https://github.com/OCA/multi-company/issues/906, since trying to fetch cached records (of field `company_ids`) caused some errors. That does not happen anymore with this PR. The other fix for this issue proposed in #907 was causing some problems too and was not entirely correct, so that's why this solution was developed.

Since always invalidating the cache for the `company_ids` field can be problematic (specially in a compute method) we only invalidate it when in fact we get the access error, and with that we fix our issue. In all other cases, we still keep the original behavior of the method, not breaking the compute logic.