### PR TITLE
[14.0][IMP] product_supplier_inter-multi_company: multi-company supplierinfo

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,6 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.38
+_commit: v1.41
 _src_path: gh:oca/oca-addons-repo-template
-ci: GitHub
 convert_readme_fragments_to_markdown: false
 enable_checklog_odoo: false
 generate_requirements_txt: true
@@ -18,6 +17,7 @@ org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups:
 - product_tax_multicompany_default
+- stock_intercompany
 repo_description: Addons for the management of multi company instances as well as
 repo_name: Multi company modules
 repo_slug: multi-company

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md)$'
+        language: fail
   - repo: https://github.com/oca/maintainer-tools
     rev: f9b919b9868143135a9c9cb03021089cabba8223
     hooks:

--- a/product_supplierinfo_intercompany_multi_company/__init__.py
+++ b/product_supplierinfo_intercompany_multi_company/__init__.py
@@ -1,1 +1,3 @@
 from . import models
+from .hooks import post_init_hook
+from .hooks import uninstall_hook

--- a/product_supplierinfo_intercompany_multi_company/__manifest__.py
+++ b/product_supplierinfo_intercompany_multi_company/__manifest__.py
@@ -2,7 +2,7 @@
     "name": "Product SupplierInfo Intercompany Multi Company",
     "summary": """
     Compatibility of product_multi_company and product_supplierinfo_intercompany""",
-    "version": "14.0.1.1.1",
+    "version": "14.0.1.2.0",
     "category": "Generic Modules/Others",
     "license": "AGPL-3",
     "author": "Ilyas, Ooops404, Odoo Community Association (OCA)",
@@ -11,6 +11,11 @@
         "product_supplierinfo_intercompany",
         "product_multi_company",
     ],
+    "data": [
+        "views/product_supplierinfo_views.xml",
+    ],
     "installable": True,
     "auto_install": True,
+    "post_init_hook": "post_init_hook",
+    "uninstall_hook": "uninstall_hook",
 }

--- a/product_supplierinfo_intercompany_multi_company/hooks.py
+++ b/product_supplierinfo_intercompany_multi_company/hooks.py
@@ -1,0 +1,22 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from odoo.addons.base_multi_company import hooks
+except ImportError:
+    _logger.info("Cannot find `base_multi_company` module in addons path.")
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    hooks.set_security_rule(env, "product.product_supplierinfo_comp_rule")
+
+
+def uninstall_hook(cr, registry):
+    hooks.uninstall_hook(
+        cr,
+        "product.product_supplierinfo_comp_rule",
+    )

--- a/product_supplierinfo_intercompany_multi_company/migrations/14.0.1.2.0/post-migrate.py
+++ b/product_supplierinfo_intercompany_multi_company/migrations/14.0.1.2.0/post-migrate.py
@@ -1,0 +1,11 @@
+from openupgradelib import openupgrade
+
+# pylint: disable=odoo-addons-relative-import
+from odoo.addons.product_supplierinfo_intercompany_multi_company.hooks import (
+    post_init_hook,
+)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    post_init_hook(env.cr, env.registry)

--- a/product_supplierinfo_intercompany_multi_company/models/__init__.py
+++ b/product_supplierinfo_intercompany_multi_company/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_intercompany_supplier_mixin
+from . import product_supplierinfo

--- a/product_supplierinfo_intercompany_multi_company/models/product_intercompany_supplier_mixin.py
+++ b/product_supplierinfo_intercompany_multi_company/models/product_intercompany_supplier_mixin.py
@@ -4,15 +4,6 @@ from odoo import models
 class ProductIntercompanySupplierMixin(models.AbstractModel):
     _inherit = "product.intercompany.supplier.mixin"
 
-    def _synchronise_supplier_info_for_record(self, pricelist, supplierinfo):
-        res = super()._synchronise_supplier_info_for_record(pricelist, supplierinfo)
-        if (
-            self._has_intercompany_price(pricelist)
-            and self.company_id == pricelist.company_id
-        ):
-            supplierinfo.sudo().unlink()
-        return res
-
     def _condition_supplierinfo_create_or_update(self, pricelist, supplierinfo):
         res = super()._condition_supplierinfo_create_or_update(pricelist, supplierinfo)
         return res and (
@@ -22,3 +13,12 @@ class ProductIntercompanySupplierMixin(models.AbstractModel):
                 and pricelist.company_id != self.company_ids
             )
         )
+
+    def _prepare_intercompany_supplier_info(self, pricelist):
+        """
+        Let the compute set the company on the supplierinfo
+        """
+        res = super()._prepare_intercompany_supplier_info(pricelist)
+        if "company_id" in res:
+            del res["company_id"]
+        return res

--- a/product_supplierinfo_intercompany_multi_company/models/product_supplierinfo.py
+++ b/product_supplierinfo_intercompany_multi_company/models/product_supplierinfo.py
@@ -1,0 +1,20 @@
+from odoo import api, fields, models
+
+
+class ProductSupplierinfo(models.Model):
+    _inherit = ["multi.company.abstract", "product.supplierinfo"]
+    _name = "product.supplierinfo"
+    _description = "Supplier Pricelist (Multi-Company)"
+
+    company_ids = fields.Many2many(
+        string="Companies",
+        comodel_name="res.company",
+        compute="_compute_company_ids",
+        store=True,
+    )
+
+    @api.depends("product_id.company_ids", "product_tmpl_id.company_ids")
+    def _compute_company_ids(self):
+        for rec in self.with_context(automatic_intercompany_sync=True):
+            product = rec.product_id or rec.product_tmpl_id
+            rec.company_ids = product.company_ids

--- a/product_supplierinfo_intercompany_multi_company/tests/__init__.py
+++ b/product_supplierinfo_intercompany_multi_company/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_supplier_multicompany

--- a/product_supplierinfo_intercompany_multi_company/tests/test_supplier_multicompany.py
+++ b/product_supplierinfo_intercompany_multi_company/tests/test_supplier_multicompany.py
@@ -1,0 +1,80 @@
+from odoo.addons.product_supplierinfo_intercompany.tests.test_supplier_intercompany import (
+    TestIntercompanySupplierCase,
+)
+
+
+class TestSupplierMultiCompany(TestIntercompanySupplierCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.other_company = cls.env["res.company"].create({"name": "Other company"})
+
+    def test_supplier_all_companies(self):
+        """
+        Product and supplierinfo belongs to all companies
+        """
+        price = 5
+        self.product_template_4.company_ids = False
+        self._add_item(self.product_template_4, price)
+
+        prod_with_other_company = self.product_template_4.with_company(
+            self.other_company
+        )
+        self._check_supplier_info_for(self.product_template_4, price)
+        self._check_supplier_info_for(prod_with_other_company, price)
+
+        supplierinfo = self._get_supplier_info(self.product_template_4)
+        self.assertFalse(supplierinfo.company_ids)
+
+    def test_supplier_some_companies(self):
+        """
+        Product and supplierinfo belong only to two companies,
+        not available to the third
+        """
+        price = 5
+        companies = self.sale_company + self.purchase_company
+        self.product_template_4.company_ids = companies
+        self._add_item(self.product_template_4, price)
+
+        # cannot use utility function _get_supplier_info
+        # because company_id is hardcoded False
+        # search from sale_company
+        user = self.env.ref("base.user_admin")
+        self.env = self.env(user=user)
+        supplierinfo_model = self.env["product.supplierinfo"]
+        user.write(
+            {
+                "company_id": self.sale_company.id,
+                "company_ids": [(6, 0, self.sale_company.ids)],
+            }
+        )
+        domain = [
+            ("name", "=", self.partner.id),
+            ("intercompany_pricelist_id", "=", self.pricelist_intercompany.id),
+            ("product_tmpl_id", "=", self.product_template_4.id),
+            ("product_id", "=", False),
+        ]
+        supplierinfo = supplierinfo_model.search(domain)
+        self.assertEqual(supplierinfo.company_ids, companies)
+
+        # run search again with other company
+        user.write(
+            {
+                "company_id": self.other_company.id,
+                "company_ids": [(6, 0, self.other_company.ids)],
+            }
+        )
+        supplierinfo.invalidate_cache()
+        supplierinfo = supplierinfo_model.search(domain)
+        self.assertFalse(supplierinfo)
+
+    def test_uninstall(self):
+        from ..hooks import uninstall_hook
+
+        uninstall_hook(self.env.cr, None)
+        rule = self.env.ref("product.product_supplierinfo_comp_rule")
+        domain = (
+            " ['|', ('company_id', '=', user.company_id.id), "
+            "('company_id', '=', False)]"
+        )
+        self.assertEqual(rule.domain_force, domain)

--- a/product_supplierinfo_intercompany_multi_company/views/product_supplierinfo_views.xml
+++ b/product_supplierinfo_intercompany_multi_company/views/product_supplierinfo_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="product_supplierinfo_form_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.form.view</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_form_view" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field
+                    name="company_ids"
+                    groups="base.group_multi_company"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="product_supplierinfo_tree_view" model="ir.ui.view">
+        <field name="name">product.supplierinfo.tree.view</field>
+        <field name="model">product.supplierinfo</field>
+        <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field
+                    name="company_ids"
+                    groups="base.group_multi_company"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                    readonly="1"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add `company_ids` to supplierinfo in order to make them visible to some but not all companies. This solves an issue with supplierinfo for products shared only among some companies.

When creating intercompany supplierinfo automatically, sync the product's `company_ids` with the `supplierinfo`.

Steps to reproduce:

- product with companies A and B and not C
- generate an intercompany supplierinfo
- With only company C, try loading the supplierinfo list view -> The supplierinfo is visible to company C, even though the product is not.

To Do:
-  [x] migration to recompute all intercompany supplierinfo
-  [x] unit test