### PR TITLE
[18.0][FIX] purchase_sale_inter_company: Clear delivery address company_id when differs from dest company

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -129,6 +129,13 @@ class PurchaseOrder(models.Model):
         """
         self.ensure_one()
         delivery_address = direct_delivery_address or partner or False
+        # Clear company_id if delivery address belongs to a different company
+        if (
+            delivery_address
+            and delivery_address.company_id
+            and delivery_address.company_id != dest_company
+        ):
+            delivery_address.company_id = False
         new_order = self.env["sale.order"].new(
             {
                 "company_id": dest_company.id,

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -359,3 +359,23 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
                 "name": "Test",
             }
         )
+
+    def test_delivery_address_different_company(self):
+        """
+        When a purchase order has a delivery address with a different company_id
+        than the destination company, the company_id should be cleared to avoid
+        validation errors when creating the inter-company sale order.
+        """
+        delivery_address = self.env["res.partner"].create(
+            {
+                "name": "Delivery Address Company A",
+                "company_id": self.company_a.id,
+            }
+        )
+        purchase = self._create_purchase_order(self.partner_company_b)
+        purchase.dest_address_id = delivery_address
+        sale = self._approve_po(purchase)
+        self.assertEqual(len(sale), 1)
+        self.assertEqual(sale.state, "sale")
+        self.assertEqual(sale.partner_shipping_id, delivery_address)
+        self.assertFalse(sale.partner_shipping_id.company_id)


### PR DESCRIPTION
In an inter-company scenario:

1. Company A creates a purchase order to Company B
2. The purchase order has a delivery address `dest_address_id` with `company_id` set to Company A

When confirming the purchase order in Company A, the process fails because:
  - The inter-company sale order being created in Company B attempts to use the delivery address from the purchase order, this delivery address has `company_id = Company A`
  - A validation error occurs because Company B cannot use a partner record with a different company assigned

The fix clears the `company_id` field from the delivery address when it differs from the destination company, allowing the inter-company sale order to be created successfully

@tecnativa @carlos-lopez-tecnativa @christian-ramos-tecnativa 