### PR TITLE
[18.0][IMP] purchase_sale_stock_inter_company: Add an option to automatically validate the purchase order

### DIFF
--- a/purchase_sale_stock_inter_company/models/__init__.py
+++ b/purchase_sale_stock_inter_company/models/__init__.py
@@ -1,6 +1,7 @@
 from . import purchase_order
 from . import res_company
 from . import res_config
+from . import stock_rule
 from . import stock_picking
 from . import stock_move_line
 from . import sale_order_line

--- a/purchase_sale_stock_inter_company/models/res_company.py
+++ b/purchase_sale_stock_inter_company/models/res_company.py
@@ -35,3 +35,9 @@ class ResCompany(models.Model):
         string="Block manual validation of picking in the destination company",
     )
     notify_user_id = fields.Many2one("res.users", "User to Notify")
+    purchase_auto_validation = fields.Boolean(
+        string="Inter-company POs Auto Validation",
+        help="When a purchase order is created from a sales order "
+        "using the MTO or Dropship rule for this company, "
+        "it will be automatically validated.",
+    )

--- a/purchase_sale_stock_inter_company/models/res_config.py
+++ b/purchase_sale_stock_inter_company/models/res_config.py
@@ -38,3 +38,10 @@ class InterCompanyRulesConfig(models.TransientModel):
         help="User to notify incase of sync picking failure.",
         readonly=False,
     )
+    purchase_auto_validation = fields.Boolean(
+        related="company_id.purchase_auto_validation",
+        help="When a purchase order is created from a sales order "
+        "using the MTO or Dropship rule for this company, "
+        "it will be automatically validated.",
+        readonly=False,
+    )

--- a/purchase_sale_stock_inter_company/models/stock_rule.py
+++ b/purchase_sale_stock_inter_company/models/stock_rule.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    @api.model
+    def _run_buy(self, procurements):
+        last_po = self.env["purchase.order"].search(
+            [],
+            order="id desc",
+            limit=1,
+        )
+        res = super()._run_buy(procurements)
+        new_po = self.env["purchase.order"].search([("id", ">", last_po.id)])
+        # Auto-confirm purchase orders linked to sale orders
+        for purchase in new_po:
+            if (
+                purchase.sale_order_count
+                and purchase.partner_id.ref_company_ids
+                and purchase.company_id.purchase_auto_validation
+            ):
+                purchase.button_confirm()
+        return res

--- a/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
+++ b/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
@@ -822,3 +822,44 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
             so_lots, po_lots, msg="The lots of the moves should be the same"
         )
         self.assertFalse(so_lots.company_id, msg="Lots should not have a company.")
+
+    def test_purchase_auto_validation_with_mto(self):
+        """Test that the purchase order is auto-validated when the sale order
+        is confirmed for a product with MTO route
+        """
+        mto_route = self.env["stock.warehouse"]._find_or_create_global_route(
+            "stock.route_warehouse0_mto", self.env._("Replenish on Order (MTO)")
+        )
+        self.company_a.purchase_auto_validation = True
+        self.env["product.supplierinfo"].create(
+            {
+                "company_id": self.company_a.id,
+                "partner_id": self.partner_company_b.id,
+                "product_id": self.stockable_product_serial.id,
+            }
+        )
+        customer = self.env["res.partner"].create({"name": "New Customer"})
+        sale_order = self.env["sale.order"].create(
+            {
+                "company_id": self.company_a.id,
+                "partner_id": customer.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.stockable_product_serial.id,
+                            "product_uom_qty": 2,
+                            "route_id": mto_route.id,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_order.action_confirm()
+        purchase = sale_order._get_purchase_orders()
+        self.assertEqual(purchase.state, "purchase")
+        new_sale_order = (
+            self.env["sale.order"]
+            .with_user(self.user_company_b)
+            .search([("auto_purchase_order_id", "=", purchase.id)])
+        )
+        self.assertEqual(new_sale_order.partner_id, self.partner_company_a)

--- a/purchase_sale_stock_inter_company/views/res_config_view.xml
+++ b/purchase_sale_stock_inter_company/views/res_config_view.xml
@@ -47,6 +47,14 @@
                     domain="[('company_id', '=', company_id)]"
                 />
             </xpath>
+            <xpath expr="//field[@name='sale_auto_validation']" position='after'>
+                <br />
+                <label
+                    for="purchase_auto_validation"
+                    class="oe_inline o_light_label mr8"
+                />
+                <field name="purchase_auto_validation" class="oe_inline" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
When the purchase order is generated from a sale order with a product using the MTO or Dropship route, the purchase order can be automatically confirmed to start the intercompany process.

TT56365
@Tecnativa @pedrobaeza @christian-ramos-tecnativa @metaminux could you please review this?