### PR TITLE
[17.0][FIX] account_multicompany_easy_creation: Fix AccessError with POS installed

### DIFF
--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
@@ -230,7 +230,9 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
         new_company = self.new_company_id.with_context(
             allowed_company_ids=allowed_company_ids
         )
-        self.env["account.chart.template"].try_loading(self.chart_template, new_company)
+        self.env["account.chart.template"].sudo().try_loading(
+            self.chart_template, new_company
+        )
         self.create_bank_journals()
         self.create_sequences()
 


### PR DESCRIPTION
- When point_of_sale is installed, loading a chart template triggers the cleanup of default POS payment methods (point_of_sale.models.chart_template._load). If the user running the Easy Creation wizard (e.g., an Account Manager) does not have POS permissions (specifically point_of_sale.group_pos_manager), this fails with an AccessError.

- This commit adds sudo() to the try_loading call in the wizard. Company creation and COA loading are administrative tasks that should succeed regardless of the user's specific access rights to other installed modules.