### PR TITLE
[18.0][FIX] base_multi_company: company_ids UID context dependent

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -19,6 +19,8 @@ class MultiCompanyAbstract(models.AbstractModel):
     company_ids = fields.Many2many(
         string="Companies",
         comodel_name="res.company",
+        # avoid cache pollution in sudo / non-sudo uses of the field
+        depends_context=("uid",),
     )
 
     @api.depends("company_ids")
@@ -80,4 +82,10 @@ class MultiCompanyAbstract(models.AbstractModel):
     def write(self, vals):
         """Discard changes in company_id field if company_ids has been given."""
         self._multicompany_patch_vals(vals)
-        return super().write(vals)
+        res = super().write(vals)
+        if "company_ids" in vals:
+            # Writing on the field without sudo won't update the sudo cache
+            # (and vice versa) so we invalidate to ensure the sudo cache is
+            # up-to-date
+            self.invalidate_recordset(fnames=["company_ids"])
+        return res

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -175,7 +175,10 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         tester.write({"company_ids": [(6, False, companies.ids)]})
         # Force recompute
         tester.invalidate_model(["company_id"])
-        self.assertFalse(tester.company_ids <= user.company_ids)  # Is not subset
+        # Is not subset
+        # Fetch it with the admin user cause company_ids is uid context dependent
+        admin = self.env.user
+        self.assertFalse(tester.with_user(admin).company_ids <= user.company_ids)
         self.assertNotEqual(tester.company_id.id, user.company_id.id)
         self.assertIn(tester.company_id.id, user.company_ids.ids)
         # Switch to a company not in tester.company_ids


### PR DESCRIPTION
Fixes the problem reported in the issue #929, using a similar approach as Odoo to solve a similar problem (this is Odoo's original fix PR --> odoo/odoo#217752).

**Note:** This fix can cause issues with the `company_ids` field tracking and the generated logs. We have proposed a PR to Odoo in order to fix this problem as well --> odoo/odoo#244529.
