### PR TITLE
[17.0][FIX] account_invoice_inter_company: Handle invoice validation in bulk from the wizard

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -46,9 +46,9 @@ class AccountMove(models.Model):
         if not supplier_invoice.ref:
             supplier_invoice.write({"ref": self.name})
 
-    def action_post(self):
+    def _post(self, soft=True):
         """Validated invoice generate cross invoice base on company rules"""
-        res = super().action_post()
+        res = super()._post(soft=soft)
         # Intercompany account entries or receipts aren't supported
         supported_types = {"out_invoice", "in_invoice", "out_refund", "in_refund"}
         for src_invoice in self.filtered(lambda x: x.move_type in supported_types):

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -599,3 +599,25 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
         )
         self.assertEqual(invoices.invoice_date.strftime("%Y-%m-%d"), "2025-01-01")
         self.assertEqual(invoices.date.strftime("%Y-%m-%d"), "2025-01-01")
+
+    def test_confirm_invoice_from_wizard(self):
+        # ensure the catalog is shared
+        self.env.ref("product.product_comp_rule").write({"active": False})
+        # Make sure there are no taxes in target company for the used product
+        self.product_a.with_user(
+            self.user_company_b.id
+        ).sudo().supplier_taxes_id = False
+        # Confirm the invoice of company A
+        wizard = (
+            self.env["validate.account.move"]
+            .with_context(
+                active_model="account.move", active_ids=[self.invoice_company_a.id]
+            )
+            .create({})
+        )
+        wizard.with_user(self.user_company_a.id).validate_move()
+        # Check destination invoice created in company B
+        invoices = self.account_move_obj.with_user(self.user_company_b.id).search(
+            [("auto_invoice_id", "=", self.invoice_company_a.id)]
+        )
+        self.assertTrue(invoices)


### PR DESCRIPTION
When the invoice is validated using the wizard
https://github.com/odoo/odoo/blob/d129570727f050b4b8d26db6951bd5dbf768d09f/addons/account/wizard/account_validate_account_move.py#L26

it calls the `_post` method instead of `action_post`, so the intercompany invoices are not created.

TT60710
@Tecnativa @pedrobaeza @victoralmau could you please review this?

<img width="1566" height="573" alt="image" src="https://github.com/user-attachments/assets/359c021a-b30a-4f41-854b-a1230936bdc3" />
