### PR TITLE
[18.0][FIX] account_invoice_inter_company: Handle tax-included and tax-excluded prices

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -3,7 +3,7 @@
 import base64
 import logging
 
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import AccessError, UserError
 from odoo.tools import float_compare
 from odoo.tools.misc import clean_context
@@ -356,7 +356,6 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         vals = {
             "product_id": self.product_id.id or False,
-            "price_unit": self.price_unit,
             "quantity": self.quantity,
             "discount": self.discount,
             "move_id": dest_move.id,
@@ -367,4 +366,23 @@ class AccountMoveLine(models.Model):
         if hasattr(self, "start_date") and hasattr(self, "end_date"):
             vals["start_date"] = self.start_date
             vals["end_date"] = self.end_date
+        new_line = self.new(vals)
+        new_taxes = new_line._get_computed_taxes()
+        vals["tax_ids"] = [Command.set(new_taxes.ids)]
+        price_unit = self.price_unit
+        base_line = self.move_id._prepare_product_base_line_for_taxes_computation(self)
+        self.env["account.tax"]._add_tax_details_in_base_line(base_line, dest_company)
+        # case where taxes in the company A are price excluded
+        # but in the company B are price included
+        if self.tax_ids.filtered("price_include") and not new_taxes.filtered(
+            "price_include"
+        ):
+            price_unit = base_line["tax_details"]["raw_total_excluded_currency"]
+        # case where taxes in the company A are price included
+        # but in the company B are price excluded
+        if not self.tax_ids.filtered("price_include") and new_taxes.filtered(
+            "price_include"
+        ):
+            price_unit = base_line["tax_details"]["raw_total_included_currency"]
+        vals["price_unit"] = price_unit
         return vals

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -296,6 +296,36 @@ class TestAccountInvoiceInterCompanyBase(TransactionCase):
         cls.product_a.with_user(
             cls.user_company_b.id
         ).sudo().property_account_expense_id = cls.a_expense_company_b.id
+        tax_group_a = cls.env["account.tax.group"].create(
+            {"name": "Tax Group A", "company_id": cls.company_a.id}
+        )
+        tax_group_b = cls.env["account.tax.group"].create(
+            {"name": "Tax Group B", "company_id": cls.company_b.id}
+        )
+        cls.tax_company_a = cls.env["account.tax"].create(
+            {
+                "name": "Tax Company A",
+                "amount_type": "percent",
+                "amount": 10.0,
+                "price_include_override": "tax_excluded",
+                "company_id": cls.company_a.id,
+                "type_tax_use": "sale",
+                "tax_group_id": tax_group_a.id,
+                "country_id": cls.env.ref("base.es").id,
+            }
+        )
+        cls.tax_company_b = cls.env["account.tax"].create(
+            {
+                "name": "Tax Company B",
+                "amount_type": "percent",
+                "amount": 10.0,
+                "price_include_override": "tax_included",
+                "company_id": cls.company_b.id,
+                "type_tax_use": "purchase",
+                "tax_group_id": tax_group_b.id,
+                "country_id": cls.env.ref("base.es").id,
+            }
+        )
 
 
 class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
@@ -519,3 +549,59 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
             [("auto_invoice_id", "=", self.invoice_company_a.id)]
         )
         self.assertTrue(invoices)
+
+    def test_tax_exclude(self):
+        """
+        When the tax configuration is different between the two companies,
+        the destination invoice must keep the same total as the origin invoice.
+        Company A has tax excluded prices
+        Company B has tax included prices
+        """
+        # ensure the catalog is shared
+        self.env.ref("product.product_comp_rule").write({"active": False})
+        # set the price_include_override to force the tax computation
+        self.tax_company_a.price_include_override = "tax_excluded"
+        self.tax_company_b.price_include_override = "tax_included"
+        self.product_a.with_user(self.user_company_a).taxes_id = [
+            Command.link(self.tax_company_a.id)
+        ]
+        self.product_a.with_user(self.user_company_b).supplier_taxes_id = [
+            Command.link(self.tax_company_b.id)
+        ]
+        self.invoice_line_a.tax_ids = [Command.set(self.tax_company_a.ids)]
+        self.invoice_company_a.with_user(self.user_company_a.id).action_post()
+        invoices = self.account_move_obj.with_user(self.user_company_b.id).search(
+            [("auto_invoice_id", "=", self.invoice_company_a.id)]
+        )
+        self.assertEqual(self.invoice_company_a.amount_untaxed, 450.0)
+        self.assertEqual(self.invoice_company_a.amount_total, 495.0)
+        self.assertEqual(invoices.amount_untaxed, 450.0)
+        self.assertEqual(invoices.amount_total, 495.0)
+
+    def test_tax_include(self):
+        """
+        When the tax configuration is different between the two companies,
+        the destination invoice must keep the same total as the origin invoice.
+        Company A has tax included prices
+        Company B has tax excluded prices
+        """
+        # ensure the catalog is shared
+        self.env.ref("product.product_comp_rule").write({"active": False})
+        # set the price_include_override to force the tax computation
+        self.tax_company_a.price_include_override = "tax_included"
+        self.tax_company_b.price_include_override = "tax_excluded"
+        self.product_a.with_user(self.user_company_a).taxes_id = [
+            Command.link(self.tax_company_a.id)
+        ]
+        self.product_a.with_user(self.user_company_b).supplier_taxes_id = [
+            Command.link(self.tax_company_b.id)
+        ]
+        self.invoice_line_a.tax_ids = [Command.set(self.tax_company_a.ids)]
+        self.invoice_company_a.with_user(self.user_company_a.id).action_post()
+        invoices = self.account_move_obj.with_user(self.user_company_b.id).search(
+            [("auto_invoice_id", "=", self.invoice_company_a.id)]
+        )
+        self.assertEqual(self.invoice_company_a.amount_untaxed, 409.09)
+        self.assertEqual(self.invoice_company_a.amount_total, 450.0)
+        self.assertEqual(invoices.amount_untaxed, 409.09)
+        self.assertEqual(invoices.amount_total, 450.0)


### PR DESCRIPTION
when creating the invoice in the other company.


TT60725
@Tecnativa @pedrobaeza @christian-ramos-tecnativa @sergio-teruel could you please review this?