### PR TITLE
[16.0][IMP] purchase_sale_stock_inter_company: enforce PO company in move vals

### DIFF
--- a/purchase_sale_stock_inter_company/models/__init__.py
+++ b/purchase_sale_stock_inter_company/models/__init__.py
@@ -2,3 +2,4 @@ from . import purchase_order
 from . import res_company
 from . import res_config
 from . import stock_picking
+from . import purchase_order_line

--- a/purchase_sale_stock_inter_company/models/purchase_order_line.py
+++ b/purchase_sale_stock_inter_company/models/purchase_order_line.py
@@ -1,0 +1,22 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = "purchase.order.line"
+
+    def _prepare_stock_move_vals(
+        self, picking, price_unit, product_uom_qty, product_uom
+    ):
+        self.ensure_one()
+        order_company = self.order_id.company_id
+        if order_company and self.env.company != order_company:
+            return super(
+                PurchaseOrderLine, self.with_company(order_company)
+            )._prepare_stock_move_vals(
+                picking, price_unit, product_uom_qty, product_uom
+            )
+        return super()._prepare_stock_move_vals(
+            picking, price_unit, product_uom_qty, product_uom
+        )


### PR DESCRIPTION
When a PO line is processed from another current company, preparing stock move values could run in the wrong company context.
Switch to the purchase order company before calling super so company-dependent values are computed consistently.