### PR TITLE
[18.0][FIX] product_tax_multicompany_default - set taxes on all companies

### DIFF
--- a/product_tax_multicompany_default/models/product.py
+++ b/product_tax_multicompany_default/models/product.py
@@ -230,7 +230,9 @@ class ProductTemplate(models.Model):
             if default_supplier_tax_ids != supplier_tax_ids
             else None
         )
-        for company in self.env["res.company"].search([("id", "!=", user_company.id)]):
+        for company in (
+            self.env["res.company"].sudo().search([("id", "!=", user_company.id)])
+        ):
             customer_tax_ids.extend(
                 self._taxes_by_company(
                     "account_sale_tax_id", company, match_customer_tax_ids


### PR DESCRIPTION
When a user who does not have access to all existing companies sets taxes for a product, it only propagates the tax to the companies to which it has access, leaving the value empty for those to which it does not have access (the `_delete_product_taxes()` method executes a `DELETE` and skips security rules).

Therefore, it is necessary to use `sudo()` when iterating through the companies to which the tax is to be propagated.