### PR TITLE
[18.0][FIX] base_multi_company: store company_id to make it available outside ORM cache

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -15,6 +15,7 @@ class MultiCompanyAbstract(models.AbstractModel):
         compute="_compute_company_id",
         search="_search_company_id",
         inverse="_inverse_company_id",
+        store=True,
     )
     company_ids = fields.Many2many(
         string="Companies",


### PR DESCRIPTION
This fix is required by `partner_property` module (see OCA/partner-contact#2290), where `_compute_properties_company_id` needs to read `company_id` from the database. When accessing a record via `with_company()`, a new environment is created that does not share the ORM cache of the original, making pending writes to `company_id` invisible to the compute method.

### Fix

Add `store=True` to `company_id` field in `MultiCompanyAbstract` so the value is always persisted in the database and accessible regardless of the ORM cache or environment context.

@Tecnativa TT60000
@christian-ramos-tecnativa @pedrobaeza 