### PR TITLE
[18.0][FIX] account_multicompany_easy_creation - only set matching taxes if any

### DIFF
--- a/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
+++ b/account_multicompany_easy_creation/wizards/multicompany_easy_creation.py
@@ -275,7 +275,15 @@ class AccountMulticompanyEasyCreationWiz(models.TransientModel):
             self.new_company_id.id, product_taxes
         )
         if tax_ids:
-            product.update({taxes_field: [Command.link(tax_id) for tax_id in tax_ids]})
+            to_unlink_taxes = product[taxes_field].filtered(
+                lambda tax: tax.company_id == self.new_company_id
+            )
+            product.update(
+                {
+                    taxes_field: [Command.unlink(t.id) for t in to_unlink_taxes]
+                    + [Command.link(tax_id) for tax_id in tax_ids]
+                }
+            )
             return True
         return False
 


### PR DESCRIPTION
When a product has a tax other than the default one and the "Smart Search Product Tax" option is selected, if the product tax exists in the new company, the product will have two taxes configured in the new company