### PR TITLE
[17.0][FIX] base_multi_company: Add uid to depends context

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -19,6 +19,9 @@ class MultiCompanyAbstract(models.AbstractModel):
     company_ids = fields.Many2many(
         string="Companies",
         comodel_name="res.company",
+        depends_context=(
+            "uid",
+        ),  # To avoid cache pollution between sudo / non-sudo uses of the field
     )
 
     @api.depends("company_ids")

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -273,12 +273,12 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         # Check set company_id
         tester.company_id = company1
 
-        self.assertEqual(tester.sudo().company_ids, company1)
+        self.assertEqual(tester.company_ids, company1)
 
         # Check remove company_id
         tester.company_id = False
 
-        self.assertFalse(tester.sudo().company_ids)
+        self.assertFalse(tester.company_ids)
 
     def test_rule_in_false(self):
         # Create an ir.rule imitating base.res_partner_rule


### PR DESCRIPTION
Steps to reproduce the error:

1. Set a contact with the companies 1 and 2
2. Enter in the contact with Demo, with just one of the companies available
3. Change any field and try to save
4. The next error will be raised because is trying to render the display_name for both companies but Demo only has access to one of them
<img width="650" height="319" alt="image" src="https://github.com/user-attachments/assets/bb03c3ae-b250-4bf3-be45-b64bd7d99cb6" />

Adding this depends solve the issue, based in the company_ids from account.account 18.0
https://github.com/odoo/odoo/blob/18.0/addons/account/models/account_account.py#L107
This change is not needed in 18.0.

@Tecnativa TT61309
@pedrobaeza @victoralmau 