### PR TITLE
[18.0][IMP] account_invoice_inter_company: support display type and retrieve invoice line name in auto invoice

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -200,10 +200,8 @@ class AccountMove(models.Model):
 
     def _create_destination_account_move_line(self, dest_invoice, dest_company):
         dest_move_line_data = []
-        for src_line in self.invoice_line_ids.filtered(
-            lambda x: x.display_type == "product"
-        ):
-            if not src_line.product_id:
+        for src_line in self.invoice_line_ids:
+            if src_line.display_type == "product" and not src_line.product_id:
                 raise UserError(
                     _(
                         "The invoice line '%(line_name)s' doesn't have a product. "
@@ -361,6 +359,8 @@ class AccountMoveLine(models.Model):
             "move_id": dest_move.id,
             "sequence": self.sequence,
             "auto_invoice_line_id": self.id,
+            "name": self.name,
+            "display_type": self.display_type,
         }
         # Compatibility with module account_invoice_start_end_dates
         if hasattr(self, "start_date") and hasattr(self, "end_date"):

--- a/account_invoice_inter_company/tests/test_inter_company_invoice.py
+++ b/account_invoice_inter_company/tests/test_inter_company_invoice.py
@@ -285,7 +285,7 @@ class TestAccountInvoiceInterCompanyBase(TransactionCase):
             line_form.quantity = 1
             line_form.product_uom_id = cls.env.ref("uom.product_uom_hour")
             line_form.account_id = cls.a_sale_company_a
-            line_form.name = "Service Multi Company"
+            line_form.name = "Service Multi Company test"
             line_form.price_unit = 450.0
         cls.invoice_company_a = cls.invoice_company_a.save()
         cls.invoice_line_a = cls.invoice_company_a.invoice_line_ids[0]
@@ -382,6 +382,7 @@ class TestAccountInvoiceInterCompany(TestAccountInvoiceInterCompanyBase):
             invoice_line.product_id,
             self.invoice_company_a.invoice_line_ids[0].product_id,
         )
+        self.assertEqual(invoice_line.name, "Service Multi Company test")
         # Cancel the invoice for company A
         invoice_origin = (
             f"{self.invoice_company_a.company_id.name} - "


### PR DESCRIPTION
Keep line description + section and note in the intercompany invoice.

Forward port of https://github.com/OCA/multi-company/pull/809
