### PR TITLE
[16.0] [FIX] purchase_sale_inter_company: take into account sale order discounts

### DIFF
--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -20,5 +20,5 @@ class SaleOrder(models.Model):
         for order in self.filtered("auto_purchase_order_id"):
             for line in order.order_line.sudo():
                 if line.auto_purchase_line_id:
-                    line.auto_purchase_line_id.price_unit = line.price_unit
+                    line._intercompany_update_purchase_line_price()
         return super().action_confirm()

--- a/purchase_sale_inter_company/models/sale_order_line.py
+++ b/purchase_sale_inter_company/models/sale_order_line.py
@@ -15,3 +15,14 @@ class SaleOrderLine(models.Model):
         readonly=True,
         copy=False,
     )
+
+    def _intercompany_update_purchase_line_price(self):
+        """Writes the net price (price_unit after discount) to the purchase line.
+
+        Can be inherited in other modules to change the behavior, for example
+        if discounts are available in the purchase order.
+        """
+        self.ensure_one()
+        self.auto_purchase_line_id.price_unit = self.price_unit * (
+            1 - self.discount / 100
+        )

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -167,6 +167,14 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         sale.action_confirm()
         self.assertEqual(self.purchase_company_a.order_line.price_unit, 10)
 
+    def test_so_change_price_with_discount(self):
+        self.company_b.sale_auto_validation = False
+        sale = self._approve_po()
+        sale.order_line.price_unit = 100
+        sale.order_line.discount = 10
+        sale.action_confirm()
+        self.assertEqual(self.purchase_company_a.order_line.price_unit, 90.0)
+
     def test_po_with_contact_as_partner(self):
         contact = self.env["res.partner"].create(
             {"name": "Test contact", "parent_id": self.partner_company_b.id}


### PR DESCRIPTION
Supersedes https://github.com/OCA/multi-company/pull/662

Currently, when a sale order line has a discount, this discount is not taken into account when updating the purchase order line price. Instead the sale order line unit price is passed to the purchase line unit price, causing an error in the valuation.