### PR TITLE
[16.0][FIX] purchase_sale_inter_company: link dest bill and PO before posting

### DIFF
--- a/purchase_sale_inter_company/models/account_move.py
+++ b/purchase_sale_inter_company/models/account_move.py
@@ -9,10 +9,10 @@ from odoo import _, models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _inter_company_create_invoice(self, dest_company):
-        res = super()._inter_company_create_invoice(dest_company)
-        if res["dest_invoice"].move_type == "in_invoice":
-            self._link_invoice_purchase(res["dest_invoice"])
+    def _create_destination_account_move_line(self, dest_invoice, dest_company):
+        res = super()._create_destination_account_move_line(dest_invoice, dest_company)
+        if dest_invoice.move_type == "in_invoice":
+            self._link_invoice_purchase(dest_invoice)
         return res
 
     def _link_invoice_purchase(self, dest_invoice):

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -275,3 +275,26 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
             purchase.order_line[0].with_context(allow_update_locked_sales=True).write(
                 {"product_qty": 99}
             )
+
+    def test_purchase_link_set_before_post(self):
+        """The bill must be linked to the PO after creating the invoice lines,
+        before posting.
+        """
+        self.partner_company_a.company_id = False
+        self.partner_company_b.company_id = False
+        sale = self._approve_po()
+        sale_invoice = sale._create_invoices()[0]
+        # Prepare the destination invoice in draft without posting
+        dest_company = self.company_a
+        src_invoice = sale_invoice.with_context(
+            skip_check_amount_difference=True,
+            check_move_validity=False,
+        )
+        dest_invoice_data = src_invoice._prepare_invoice_data(dest_company)
+        dest_invoice = src_invoice.create(dest_invoice_data)
+        src_invoice._create_destination_account_move_line(dest_invoice, dest_company)
+        # The purchase link must already be set before any posting
+        self.assertEqual(
+            dest_invoice.invoice_line_ids.purchase_line_id,
+            self.purchase_company_a.order_line,
+        )


### PR DESCRIPTION
Currently, the link between the autogenerated bill and it's PO is done after the bill has been already posted. This can cause issues, for example if the price from the bill differs from the price of the purchase.