### PR TITLE
[18.0][FIX] partner_multi_company: company_ids propagation to children

### DIFF
--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -32,6 +32,11 @@ class ResPartner(models.Model):
         commercial_fields += ["company_ids"]
         return commercial_fields
 
+    def _commercial_sync_to_children(self, fields_to_sync=None):
+        if fields_to_sync and "company_ids" in fields_to_sync:
+            self.invalidate_recordset(fnames=["company_ids"], flush=False)
+        return super()._commercial_sync_to_children(fields_to_sync)
+
     @api.model
     def _amend_company_id(self, vals):
         if "company_ids" in vals:


### PR DESCRIPTION
Currently, when we modify the company_ids field in a parent contact, the modification is applied on children at the next write().