### PR TITLE
[18.0][FIX] purchase_sale_inter_company: Handle tax-included and tax-excluded prices

### DIFF
--- a/purchase_sale_inter_company/models/sale_order.py
+++ b/purchase_sale_inter_company/models/sale_order.py
@@ -20,5 +20,5 @@ class SaleOrder(models.Model):
         for order in self.filtered("auto_purchase_order_id"):
             for line in order.order_line.sudo():
                 if line.auto_purchase_line_id:
-                    line.auto_purchase_line_id.price_unit = line.price_unit
+                    line._sync_price_unit_to_intercompany_purchase_line()
         return super().action_confirm()

--- a/purchase_sale_inter_company/models/sale_order_line.py
+++ b/purchase_sale_inter_company/models/sale_order_line.py
@@ -15,3 +15,31 @@ class SaleOrderLine(models.Model):
         readonly=True,
         copy=False,
     )
+
+    def _sync_price_unit_to_intercompany_purchase_line(self):
+        """
+        This method is used to sync the price unit
+        of the sale order line to the price unit
+        of the purchase order line in case of intercompany sale.
+        It takes into account the tax inclusion/exclusion
+        of both the sale order line and the purchase order line.
+        """
+        dest_taxes = self.auto_purchase_line_id.taxes_id
+        price_unit = self.price_unit
+        base_line = self._prepare_base_line_for_taxes_computation(quantity=1)
+        self.env["account.tax"]._add_tax_details_in_base_line(
+            base_line, self.company_id
+        )
+        # case where taxes in the company A are price excluded
+        # but in the company B are price included
+        if self.tax_id.filtered("price_include") and not dest_taxes.filtered(
+            "price_include"
+        ):
+            price_unit = base_line["tax_details"]["raw_total_excluded_currency"]
+        # case where taxes in the company A are price included
+        # but in the company B are price excluded
+        if not self.tax_id.filtered("price_include") and dest_taxes.filtered(
+            "price_include"
+        ):
+            price_unit = base_line["tax_details"]["raw_total_included_currency"]
+        self.auto_purchase_line_id.price_unit = price_unit

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -379,3 +379,78 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         self.assertEqual(sale.state, "sale")
         self.assertEqual(sale.partner_shipping_id, delivery_address)
         self.assertFalse(sale.partner_shipping_id.company_id)
+
+    def test_tax_exclude(self):
+        """
+        When the tax configuration is different between the two companies,
+        the purchase order must keep the same total as the sale order.
+        Company A has tax included prices
+        Company B has tax excluded prices
+        """
+        self.company_b.sale_auto_validation = False
+        # set the price_include_override to force the tax computation
+        self.tax_company_a.write(
+            {"price_include_override": "tax_included", "type_tax_use": "purchase"}
+        )
+        self.tax_company_b.write(
+            {"price_include_override": "tax_excluded", "type_tax_use": "sale"}
+        )
+        self.product.with_company(self.company_a).supplier_taxes_id = [
+            Command.link(self.tax_company_a.id)
+        ]
+        self.product.with_company(self.company_b).taxes_id = [
+            Command.link(self.tax_company_b.id)
+        ]
+        self.purchase_company_a.order_line.taxes_id = [
+            Command.set(self.tax_company_a.ids)
+        ]
+
+        sale = self._approve_po()
+        self.assertEqual(sale.order_line.tax_id, self.tax_company_b)
+        sale.order_line.price_unit = 150.0
+        sale.action_confirm()
+        # the quantity is 3, so 150 * 3 = 450
+        self.assertAlmostEqual(sale.amount_untaxed, 450.0, places=0)
+        self.assertAlmostEqual(sale.amount_total, 495.0, places=0)
+        self.assertAlmostEqual(
+            self.purchase_company_a.order_line.price_unit, 165.0, places=0
+        )
+        self.assertAlmostEqual(self.purchase_company_a.amount_untaxed, 450.0, places=0)
+        self.assertAlmostEqual(self.purchase_company_a.amount_total, 495.0, places=0)
+
+    def test_tax_include(self):
+        """
+        When the tax configuration is different between the two companies,
+        the purchase order must keep the same total as the sale order.
+        Company A has tax excluded prices
+        Company B has tax included prices
+        """
+        self.company_b.sale_auto_validation = False
+        # set the price_include_override to force the tax computation
+        self.tax_company_a.write(
+            {"price_include_override": "tax_excluded", "type_tax_use": "purchase"}
+        )
+        self.tax_company_b.write(
+            {"price_include_override": "tax_included", "type_tax_use": "sale"}
+        )
+        self.product.with_company(self.company_a).supplier_taxes_id = [
+            Command.link(self.tax_company_a.id)
+        ]
+        self.product.with_company(self.company_b).taxes_id = [
+            Command.link(self.tax_company_b.id)
+        ]
+        self.purchase_company_a.order_line.taxes_id = [
+            Command.set(self.tax_company_a.ids)
+        ]
+        sale = self._approve_po()
+        self.assertEqual(sale.order_line.tax_id, self.tax_company_b)
+        sale.order_line.price_unit = 150.0
+        sale.action_confirm()
+        # the quantity is 3, so 150 * 3 = 450
+        self.assertAlmostEqual(sale.amount_untaxed, 409, places=0)
+        self.assertAlmostEqual(sale.amount_total, 450.0, places=0)
+        self.assertAlmostEqual(
+            self.purchase_company_a.order_line.price_unit, 136.0, places=0
+        )
+        self.assertAlmostEqual(self.purchase_company_a.amount_untaxed, 409, places=0)
+        self.assertAlmostEqual(self.purchase_company_a.amount_total, 450.0, places=0)


### PR DESCRIPTION
when syncing sale orders from company B to purchase orders in company A

Similar to https://github.com/OCA/multi-company/pull/939

TT61743
@Tecnativa @pedrobaeza @christian-ramos-tecnativa @sergio-teruel could you please review this?

