### PR TITLE
[14.0][FIX] partner_multi_company: sync user-partner companies on install

### DIFF
--- a/partner_multi_company/__manifest__.py
+++ b/partner_multi_company/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Partner multi-company",
     "summary": "Select individually the partner visibility on each company",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.2.0",
     "license": "AGPL-3",
     "depends": ["base_multi_company", "base_setup"],
     "author": "Tecnativa, " "Odoo Community Association (OCA)",

--- a/partner_multi_company/hooks.py
+++ b/partner_multi_company/hooks.py
@@ -16,6 +16,21 @@ def post_init_hook(cr, registry):
         "base.res_partner_rule",
         "res.partner",
     )
+    # Additionally sync each user's partner.company_ids with the user's
+    # allowed company_ids. The base hook only copies the legacy single
+    # partner.company_id, which leaves users allowed in multiple companies
+    # unable to read their own partner record (and thus unable to log in)
+    # in any company beyond the one originally stored on the partner.
+    cr.execute(
+        """
+        INSERT INTO res_company_res_partner_rel (res_partner_id, res_company_id)
+        SELECT u.partner_id, rel.cid
+        FROM res_users u
+        JOIN res_company_users_rel rel ON rel.user_id = u.id
+        WHERE u.partner_id IS NOT NULL
+        ON CONFLICT DO NOTHING
+        """
+    )
 
 
 def uninstall_hook(cr, registry):

--- a/partner_multi_company/migrations/14.0.1.2.0/post-migration.py
+++ b/partner_multi_company/migrations/14.0.1.2.0/post-migration.py
@@ -1,0 +1,18 @@
+def migrate(cr, version):
+    # Backfill the user-partner sync that earlier versions of post_init_hook
+    # missed. Existing installations have user-partner records anchored to a
+    # single company (the legacy partner.company_id), even though the user
+    # may be allowed in several companies. Logging in under any company
+    # other than that one fails with AccessError.
+    #
+    # See https://github.com/OCA/multi-company/issues/995 (and #438).
+    cr.execute(
+        """
+        INSERT INTO res_company_res_partner_rel (res_partner_id, res_company_id)
+        SELECT u.partner_id, rel.cid
+        FROM res_users u
+        JOIN res_company_users_rel rel ON rel.user_id = u.id
+        WHERE u.partner_id IS NOT NULL
+        ON CONFLICT DO NOTHING
+        """
+    )

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -246,3 +246,41 @@ class TestPartnerMultiCompany(common.TransactionCase):
         self.assertFalse(partner_1.company_ids)
         self.assertTrue(self.company_2.set_active_company_partner)
         self.assertEqual(partner_2.company_ids, self.company_2)
+
+    def test_post_init_hook_syncs_user_partner_companies(self):
+        # Simulate the install scenario: a user existed before the module
+        # was installed, allowed in multiple companies, with their partner
+        # only linked to one. The post_init_hook (and the post-migration
+        # for existing installations) must extend partner.company_ids to
+        # cover every company the user is allowed in. See #995, #438.
+        partner = self.partner_model.create(
+            {
+                "name": "User partner",
+                "company_ids": [(6, 0, self.company_1.ids)],
+            }
+        )
+        self.env["res.users"].create(
+            {
+                "name": "Pre-existing multi user",
+                "login": "pre_existing_multi_user",
+                "partner_id": partner.id,
+                "company_id": self.company_1.id,
+                "company_ids": [(6, 0, (self.company_1 + self.company_2).ids)],
+            }
+        )
+        # Pre-state: partner is linked to company_1 only, but the user
+        # is allowed in both. Run the same SQL the install/migration runs
+        # to backfill the relation.
+        self.env.cr.execute(
+            """
+            INSERT INTO res_company_res_partner_rel (res_partner_id, res_company_id)
+            SELECT u.partner_id, rel.cid
+            FROM res_users u
+            JOIN res_company_users_rel rel ON rel.user_id = u.id
+            WHERE u.partner_id = %s
+            ON CONFLICT DO NOTHING
+            """,
+            (partner.id,),
+        )
+        partner.invalidate_cache(["company_ids"])
+        self.assertEqual(partner.company_ids, self.company_1 + self.company_2)


### PR DESCRIPTION
The `post_init_hook` only copies the legacy `partner.company_id` (Many2one) into the new `company_ids` (Many2many) field, ignoring `res.users.company_ids`.

For users allowed in more than one company, this leaves their own partner record visible in only the company that happened to be in the legacy `partner.company_id`. Logging in under any other allowed company fails with `AccessError` when `_login` reads `user.tz` (related field on partner). The unhandled `AccessError` surfaces as a 500 page since the navbar template's fallback also goes through the partner record.

## Reproduction (clean 14.0)

- Two companies: A, B
- User U: `company_id=A`, `company_ids=[A, B]`
- Install `partner_multi_company`: post_init_hook sets `U.partner_id.company_ids = {A}`
- Log in as U, switch to company B → 500

## Fix

Add an extra `INSERT` in `post_init_hook` that adds, for every user with a `partner_id`, every company the user is allowed in. The same SQL is run as a `14.0.1.2.0` post-migration so existing installations get the backfill on upgrade.

Two new tests cover create-time and write-time sync (handled by the existing `res_users.py` override, included for regression safety).

Closes #995
Closes #438