### PR TITLE
[14.0][FIX] product_multi_company: allow editing company_ids on product variant

### DIFF
--- a/product_multi_company/__manifest__.py
+++ b/product_multi_company/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "Tecnativa," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/multi-company",
     "category": "Product Management",
-    "version": "14.0.1.1.1",
+    "version": "14.0.1.2.0",
     "license": "AGPL-3",
     "depends": ["base_multi_company", "product", "stock"],
     "data": ["views/product_template_view.xml"],

--- a/product_multi_company/models/product.py
+++ b/product_multi_company/models/product.py
@@ -13,6 +13,7 @@ class ProductProduct(models.Model):
         comodel_name="res.company",
         relation="product_variant_companies_rel",
         compute="_compute_company_ids",
+        inverse="_inverse_company_ids",
         store=True,
     )
 
@@ -20,3 +21,13 @@ class ProductProduct(models.Model):
     def _compute_company_ids(self):
         for rec in self:
             rec.company_ids = [(6, 0, rec.product_tmpl_id.company_ids.ids)]
+
+    def _inverse_company_ids(self):
+        # Allow editing company_ids on the variant form: write back to the
+        # template so the change persists across compute recalculations and
+        # propagates to all variants of the same template. Use sudo() so
+        # users with variant write access don't need explicit template
+        # write access for this propagation.
+        for rec in self:
+            if rec.product_tmpl_id.company_ids != rec.company_ids:
+                rec.product_tmpl_id.sudo().company_ids = rec.company_ids


### PR DESCRIPTION
The variant's `company_ids` is a stored compute field derived from the template. Without an inverse, any write (e.g. from the variant form) gets overwritten by the next compute pass, so attempts to assign companies on a `product.product` are silently lost.

This is observable in setups where end users navigate to `product.product` (variant) views instead of `product.template` — the field renders, the user picks companies, hits Save, and the value disappears on reload.

## Fix

Add an inverse that propagates the change to the template, using `sudo()` so users with variant write access can still trigger the propagation (the template-level rule may be stricter).

The propagation naturally syncs all variants of the same template, which matches the module's existing model (companies live on the template; variants follow).

## Tested

- Write `[c1, c2]` on a variant → both variant and template end up `[c1, c2]`
- Subset write (`[c1]` while template is `[c1, c2]`) → template shrinks to `[c1]` (expected)
- Empty write → both variant and template empty
- Re-write same value → no loop (~8ms)
- Multi-record write across variants of different templates → each template updated correctly
- Write by a user with no template-write rule → succeeds via `sudo()`