### PR TITLE
[FIX] purchase_sale_inter_company Fix test

### DIFF
--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -146,7 +146,7 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         self.assertEqual(
             sale.order_line.product_id, self.product.product_variant_ids[0]
         )
-        self.assertEqual(str(sale.note), "<p>Test note</p>")
+        self.assertEqual(str(sale.note), "<span>Test note</span>")
 
     def test_not_auto_validate(self):
         self.company_b.sale_auto_validation = False


### PR DESCRIPTION
Fix failing test

```
Traceback (most recent call last):
  File "/__w/multi-company/multi-company/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py", line 149, in test_purchase_sale_inter_company
    self.assertEqual(str(sale.note), "<p>Test note</p>")
AssertionError: '<span>Test note</span>' != '<p>Test note</p>'
```