### PR TITLE
[FIX] product_category_company_favorite: use sudo to avoid error

### DIFF
--- a/product_category_company_favorite/models/product_category.py
+++ b/product_category_company_favorite/models/product_category.py
@@ -23,6 +23,14 @@ class ProductCategory(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        # if is_favorite is not in the vals keys for none of the items
+        # to create, we consider that the settings is not done
+        # so we put all categories as favorite
+        # this case can occures for exemple, if categories
+        # are created via import.
+        if all(["is_favorite" not in vals.keys() for vals in vals_list]):
+            for vals in vals_list:
+                vals["is_favorite"] = True
         categories = super().create(vals_list)
         # Configure is_favorite for all the other companies
         company_ids = (
@@ -33,7 +41,9 @@ class ProductCategory(models.Model):
         )
         for company_id in company_ids:
             for category in categories:
-                ctx_category = category.with_company(company_id)
+                # We use sudo here, in case current user doesn't have
+                # access to all companies.
+                ctx_category = category.sudo().with_company(company_id)
                 if ctx_category.parent_id:
                     # We inherit the contextual configuration of the parent category, if any
                     ctx_category.is_favorite = ctx_category.parent_id.is_favorite

--- a/product_category_company_favorite/tests/test_module.py
+++ b/product_category_company_favorite/tests/test_module.py
@@ -54,6 +54,7 @@ class TestModule(common.TransactionCase):
             {
                 "name": "New Child Category",
                 "parent_id": new_root_categ.id,
+                "is_favorite": False,
             }
         )
         self.assertFalse(new_child_categ.is_favorite)
@@ -73,9 +74,19 @@ class TestModule(common.TransactionCase):
             {
                 "name": "New Child Category",
                 "parent_id": new_root_categ.id,
+                "is_favorite": True,
             }
         )
         self.assertTrue(self._change_company(new_child_categ).is_favorite)
+
+    def test_22_create_new_category_favorite_undefined(self):
+        new_root_categ = self.ProductCategory.create(
+            {
+                "name": "New Root Category",
+            }
+        )
+        self.assertTrue(new_root_categ.is_favorite)
+        self.assertTrue(self._change_company(new_root_categ).is_favorite)
 
     def test_30_create_new_company(self):
         company_vals = {


### PR DESCRIPTION
-  if current user doesn't have access to all companies.
- put is_favorite to True, if it is not set in vals, that occures if categories are created via batch, import, etc...