### PR TITLE
[14.0][FIX] product_supplierinfo_intercompany: has_intercompany_price computation

### DIFF
--- a/product_supplierinfo_intercompany/__manifest__.py
+++ b/product_supplierinfo_intercompany/__manifest__.py
@@ -14,7 +14,7 @@
         "purchase_sale_inter_company",
     ],
     "data": ["views/pricelist_views.xml", "security/supplierinfo.xml"],
-    "demo": ["demo/pricelist.xml"],
+    "demo": ["demo/product_pricelist_demo.xml"],
     "installable": True,
     "maintainers": ["PierrickBrun", "sebastienbeau", "kevinkhao"],
 }

--- a/product_supplierinfo_intercompany/demo/product_pricelist_demo.xml
+++ b/product_supplierinfo_intercompany/demo/product_pricelist_demo.xml
@@ -8,14 +8,6 @@
         <field name="name">Pricelist Intercompany</field>
         <field name="company_id" ref="base.main_company" />
         <field name="is_intercompany_supplier" eval="True" />
-        <field
-            name="item_ids"
-            eval="[(0, 0, {
-            'product_tmpl_id': ref('product.product_product_1_product_template'),
-            'base': 'list_price',
-            'fixed_price': 5,
-        })]"
-        />
     </record>
 
     <record id="pricelist_not_intercompany" model="product.pricelist">
@@ -24,8 +16,20 @@
         <field name="is_intercompany_supplier" eval="False" />
     </record>
 
+    <record id="pricelist_item_product_template_1" model="product.pricelist.item">
+        <field name="pricelist_id" ref="pricelist_intercompany" />
+        <field name="applied_on">1_product</field>
+        <field
+            name="product_tmpl_id"
+            ref="product.product_product_1_product_template"
+        />
+        <field name="base" eval="'list_price'" />
+        <field name="fixed_price">5</field>
+    </record>
+
     <record id="pricelist_item_product_template_4" model="product.pricelist.item">
         <field name="pricelist_id" ref="pricelist_intercompany" />
+        <field name="applied_on">1_product</field>
         <field
             name="product_tmpl_id"
             ref="product.product_product_4_product_template"
@@ -36,6 +40,7 @@
 
     <record id="pricelist_item_product_product_4b" model="product.pricelist.item">
         <field name="pricelist_id" ref="pricelist_intercompany" />
+        <field name="applied_on">0_product_variant</field>
         <field
             name="product_tmpl_id"
             ref="product.product_product_4_product_template"
@@ -47,6 +52,7 @@
 
     <record id="pricelist_item_product_product_2" model="product.pricelist.item">
         <field name="pricelist_id" ref="pricelist_intercompany" />
+        <field name="applied_on">0_product_variant</field>
         <field
             name="product_tmpl_id"
             ref="product.product_product_2_product_template"

--- a/product_supplierinfo_intercompany/models/product_product.py
+++ b/product_supplierinfo_intercompany/models/product_product.py
@@ -46,16 +46,17 @@ class ProductProduct(models.Model):
 
     def _has_intercompany_price(self, pricelist):
         self.ensure_one()
-        if (
-            self.env["product.pricelist.item"].search(
-                [
-                    ("pricelist_id", "=", pricelist.id),
-                    ("product_id", "=", self.id),
-                ]
-            )
-            and pricelist.is_intercompany_supplier
+        if not pricelist.is_intercompany_supplier:
+            return False
+        if self.env["product.pricelist.item"].search(
+            [
+                ("pricelist_id", "=", pricelist.id),
+                ("applied_on", "=", "0_product_variant"),
+                ("product_id", "=", self.id),
+            ]
         ):
             return True
+        return False
 
     @api.depends("product_tmpl_id.pricelist_item_ids.fixed_price")
     def _compute_product_price(self):

--- a/product_supplierinfo_intercompany/models/product_template.py
+++ b/product_supplierinfo_intercompany/models/product_template.py
@@ -24,11 +24,13 @@ class ProductTemplate(models.Model):
 
     def _has_intercompany_price(self, pricelist):
         self.ensure_one()
+        if not pricelist.is_intercompany_supplier:
+            return False
         if self.env["product.pricelist.item"].search(
             [
                 ("pricelist_id", "=", pricelist.id),
+                ("applied_on", "=", "1_product"),
                 ("product_tmpl_id", "=", self.id),
-                ("product_id", "=", False),
             ]
         ):
             return True
@@ -36,8 +38,7 @@ class ProductTemplate(models.Model):
             [
                 ("pricelist_id", "=", pricelist.id),
                 ("applied_on", "=", "2_product_category"),
-                ("product_tmpl_id", "=", False),
-                ("product_id", "=", False),
+                ("categ_id", "parent_of", self.categ_id.id),
             ]
         ):
             return True
@@ -45,11 +46,10 @@ class ProductTemplate(models.Model):
             [
                 ("pricelist_id", "=", pricelist.id),
                 ("applied_on", "=", "3_global"),
-                ("product_tmpl_id", "=", False),
-                ("product_id", "=", False),
             ]
         ):
             return True
+        return False
 
     @api.depends("pricelist_item_ids.fixed_price")
     def _compute_template_price(self):

--- a/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
+++ b/product_supplierinfo_intercompany/tests/test_supplier_intercompany.py
@@ -42,12 +42,18 @@ class TestIntercompanySupplierCase(SavepointCase):
         if record._name == "product.product":
             vals.update(
                 {
+                    "applied_on": "0_product_variant",
                     "product_id": record.id,
                     "product_tmpl_id": record.product_tmpl_id.id,
                 }
             )
         else:
-            vals["product_tmpl_id"] = record.id
+            vals.update(
+                {
+                    "applied_on": "1_product",
+                    "product_tmpl_id": record.id,
+                }
+            )
         res = self.env["product.pricelist.item"].create(vals)
         return res
 
@@ -176,7 +182,7 @@ class TestIntercompanySupplier(TestIntercompanySupplierCase):
         self._check_supplier_info_for(product, 22)
 
     def test_add_template_item(self):
-        template = self.env.ref("product.product_product_2_product_template")
+        template = self.env.ref("product.product_product_3_product_template")
         self._add_item(template, 30)
         self._check_supplier_info_for(template, 30)
         template.active = False


### PR DESCRIPTION
- First commit fixes demo data
- Second commit (the important one) fixes the computation of has_intercompany_price

Steps to reproduce

1. Create an intercompany pricelist with one item that applies to a product category
    - Verify that intercompany supplierinfo are only generated for products in that category
2. Add a pricelist item that applies to all products
    - Verify that intercompany supplierinfo are generated for all applicable products (can be sold and purchased)
3. Remove the pricelist item that applies to all products
    - Without this PR, no supplierinfo would be deleted
    - After this PR, the generated supplierinfo are once again the same as in step 1