### PR TITLE
[FIX] product_supplierinfo_inter-multi_company: set companies on create

### DIFF
--- a/product_supplierinfo_intercompany_multi_company/models/product_supplierinfo.py
+++ b/product_supplierinfo_intercompany_multi_company/models/product_supplierinfo.py
@@ -18,3 +18,13 @@ class ProductSupplierinfo(models.Model):
         for rec in self.with_context(automatic_intercompany_sync=True):
             product = rec.product_id or rec.product_tmpl_id
             rec.company_ids = product.company_ids
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        for rec in res:
+            # the default value of company_id is automatically set
+            # so we need to force the computation on creation
+            if rec.intercompany_pricelist_id:
+                rec._compute_company_ids()
+        return res

--- a/product_supplierinfo_intercompany_multi_company/tests/test_supplier_multicompany.py
+++ b/product_supplierinfo_intercompany_multi_company/tests/test_supplier_multicompany.py
@@ -8,33 +8,56 @@ class TestSupplierMultiCompany(TestIntercompanySupplierCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.other_company = cls.env["res.company"].create({"name": "Other company"})
+        cls.product_template_3 = cls.env.ref(
+            "product.product_product_3_product_template"
+        )
 
     def test_supplier_all_companies(self):
         """
         Product and supplierinfo belongs to all companies
         """
+        product = self.product_template_3
+        self._check_no_supplier_info_for(product)
         price = 5
-        self.product_template_4.company_ids = False
-        self._add_item(self.product_template_4, price)
+        product.company_ids = False
+        self._add_item(product, price)
 
-        prod_with_other_company = self.product_template_4.with_company(
-            self.other_company
+        # Search and compare manually instead of using
+        # _get_supplier info/_check_supplier_info_for
+        # compat with product_supplierinfo_group
+        domain = [
+            ("name", "=", self.partner.id),
+            ("intercompany_pricelist_id", "=", self.pricelist_intercompany.id),
+            ("product_tmpl_id", "=", product.id),
+            ("product_id", "=", False),
+        ]
+        supplierinfo = self.env["product.supplierinfo"].search(domain)
+        self.assertEqual(len(supplierinfo), 1)
+        self.assertEqual(supplierinfo.price, price)
+        self.assertEqual(
+            supplierinfo.currency_id, supplierinfo.intercompany_pricelist_id.currency_id
         )
-        self._check_supplier_info_for(self.product_template_4, price)
-        self._check_supplier_info_for(prod_with_other_company, price)
-
-        supplierinfo = self._get_supplier_info(self.product_template_4)
         self.assertFalse(supplierinfo.company_ids)
+
+        product.with_company(self.other_company)
+        supplierinfo_other_company = (
+            self.env["product.supplierinfo"]
+            .with_company(self.other_company)
+            .search(domain)
+        )
+        self.assertEqual(supplierinfo, supplierinfo_other_company)
 
     def test_supplier_some_companies(self):
         """
         Product and supplierinfo belong only to two companies,
         not available to the third
         """
+        product = self.product_template_3
+        self._check_no_supplier_info_for(product)
         price = 5
         companies = self.sale_company + self.purchase_company
-        self.product_template_4.company_ids = companies
-        self._add_item(self.product_template_4, price)
+        product.company_ids = companies
+        self._add_item(product, price)
 
         # cannot use utility function _get_supplier_info
         # because company_id is hardcoded False
@@ -51,7 +74,7 @@ class TestSupplierMultiCompany(TestIntercompanySupplierCase):
         domain = [
             ("name", "=", self.partner.id),
             ("intercompany_pricelist_id", "=", self.pricelist_intercompany.id),
-            ("product_tmpl_id", "=", self.product_template_4.id),
+            ("product_tmpl_id", "=", product.id),
             ("product_id", "=", False),
         ]
         supplierinfo = supplierinfo_model.search(domain)


### PR DESCRIPTION
Steps to reproduce:

- Create a pricelist with one or two lines
- Set it as intercompany pricelist -> Supplierinfo are created
  with only the active company (wrong)
- Make a change that triggers a recomputation
  (e.g. change the price on the pricelist items) -> Supplierinfo
  are updated with all the correct companies

Due to the default value of company_id, the computation of company_ids
was not triggered on creation. We have to ensure it's called.

Previously tests passed because the supplierinfo was already created by demo data, so I changed the product being checked and added a check that supplierinfo didn't already exist before the start of the test.