### PR TITLE
[18.0][IMP] purchase_sale_inter_company: Allow canceling the purchase order…

### DIFF
--- a/purchase_sale_inter_company/models/purchase_order.py
+++ b/purchase_sale_inter_company/models/purchase_order.py
@@ -205,11 +205,8 @@ class PurchaseOrder(models.Model):
             .search([("auto_purchase_order_id", "in", self.ids)])
         )
         for so in sale_orders:
-            if so.state not in ["draft", "sent", "cancel"]:
-                raise UserError(
-                    self.env._("You can't cancel an order that is %s", so.state)
-                )
-        for so in sale_orders:
-            so.action_cancel()
+            # inject the disable_cancel_warning context key
+            # to cancel directly instead of displaying the wizard.
+            so.with_context(disable_cancel_warning=True).action_cancel()
         self.write({"partner_ref": False})
         return super().button_cancel()

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -213,10 +213,8 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
     def test_cancel_confirmed_po_so(self):
         self.company_b.sale_auto_validation = True
         sale = self._approve_po()
-        with self.assertRaisesRegex(
-            UserError, f"You can't cancel an order that is {sale.state}"
-        ):
-            self.purchase_company_a.with_user(self.user_company_a).button_cancel()
+        self.purchase_company_a.with_user(self.user_company_a).button_cancel()
+        self.assertEqual(sale.state, "cancel")
 
     def test_so_change_price(self):
         self.company_b.sale_auto_validation = False


### PR DESCRIPTION
… when the sales order is automatically confirmed

This module adds an option to automatically confirm the sales order generated from a purchase order. When this option is enabled, attempting to cancel the purchase order triggers a validation error. However, this module also supports automatically canceling the related sales order when the purchase order is canceled. Therefore, this restriction is contradictory and has been removed.

Additionally, the `disable_cancel_warning` context key is injected to cancel the sale order directly instead of displaying the confirmation wizard.

TT62901
@Tecnativa @pedrobaeza @carlosdauden @christian-ramos-tecnativa @victoralmau could you please review this?