### PR TITLE
[18.0][IMP] purchase_sale_stock_inter_company: Add support for synchronizing goods returns

### DIFF
--- a/purchase_sale_stock_inter_company/__init__.py
+++ b/purchase_sale_stock_inter_company/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/purchase_sale_stock_inter_company/models/__init__.py
+++ b/purchase_sale_stock_inter_company/models/__init__.py
@@ -2,5 +2,6 @@ from . import purchase_order
 from . import res_company
 from . import res_config
 from . import stock_picking
+from . import stock_move
 from . import stock_move_line
 from . import sale_order_line

--- a/purchase_sale_stock_inter_company/models/stock_move.py
+++ b/purchase_sale_stock_inter_company/models/stock_move.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _should_bypass_reservation(self, forced_location=False):
+        # When this is a return picking, we want to bypass the reservation
+        # because the stock is not yet available
+        # in the intercompany location of this company
+        # it is still located in the other company.
+        if (
+            self.picking_id._is_intercompany_return_reception()
+            and self.picking_id.return_id._is_intercompany_delivery()
+        ):
+            return True
+        return super()._should_bypass_reservation(forced_location=forced_location)

--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -107,6 +107,11 @@ class StockPicking(models.Model):
                         and x.state not in ["done", "cancel"]
                     )
                 )
+                # stock_restrict_lot compatibility
+                if "restrict_lot_id" in move._fields:
+                    po_move_pending = po_move_pending.filtered(
+                        lambda x, move=move: x.restrict_lot_id == move.restrict_lot_id
+                    )
                 po_move_lines = po_move_pending.move_line_ids
                 # Don’t raise an error
                 # if there are no move_line_ids and the location is transit.

--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -41,7 +41,10 @@ class StockPicking(models.Model):
         # block the validation of the picking in the destination company
         if self.filtered(
             lambda picking: picking.company_id.block_po_manual_picking_validation
-            and picking._is_intercompany_reception()
+            and (
+                picking._is_intercompany_reception()
+                or picking._is_intercompany_return_delivery()
+            )
             and picking.state in ["done", "waiting", "assigned"]
         ):
             raise UserError(
@@ -55,7 +58,10 @@ class StockPicking(models.Model):
     def _action_done(self):
         res = super()._action_done()
         # Only DropShip pickings
-        for picking in self.filtered(lambda pick: pick._is_intercompany_delivery()):
+        for picking in self.filtered(
+            lambda pick: pick._is_intercompany_delivery()
+            or pick._is_intercompany_return_reception()
+        ):
             purchase = picking.sale_id.sudo().auto_purchase_order_id
             picking.sudo()._action_done_intercompany_actions(purchase)
         return res
@@ -108,19 +114,19 @@ class StockPicking(models.Model):
                 # but in transit locations,
                 # we need to create the move lines to assign lots/serials.
                 if not po_move_pending or (
-                    po_move_lines and move.location_dest_id.usage != "transit"
+                    po_move_lines
+                    and (
+                        move.location_dest_id.usage != "transit"
+                        and not move.picking_id._is_intercompany_return_reception()
+                    )
                 ):
                     raise UserError(
-                        _(
+                        self.env._(
                             "There's no corresponding line in PO %(po)s for assigning "
-                            "qty from %(pick_name)s for product %(product)s"
-                        )
-                        % (
-                            {
-                                "po": purchase.name,
-                                "pick_name": self.name,
-                                "product": move.product_id.display_name,
-                            }
+                            "qty from %(pick_name)s for product %(product)s",
+                            po=purchase.name,
+                            pick_name=self.name,
+                            product=move.product_id.display_name,
                         )
                     )
                 move_line_diff = len(move_lines) - len(po_move_lines)
@@ -213,7 +219,8 @@ class StockPicking(models.Model):
         :return: bool
         """
         return (
-            self.location_id.usage in ["supplier", "transit"]
+            not self.return_id
+            and self.location_id.usage in ["supplier", "transit"]
             and self.purchase_id.sudo().intercompany_sale_order_id
         )
 
@@ -223,6 +230,29 @@ class StockPicking(models.Model):
         :return: bool
         """
         return (
-            self.location_dest_id.usage in ["customer", "transit"]
+            not self.return_id
+            and self.location_dest_id.usage in ["customer", "transit"]
             and self.sale_id.sudo().auto_purchase_order_id
+        )
+
+    def _is_intercompany_return_reception(self):
+        """
+        Check if the picking is an inter-company return reception.
+        :return: bool
+        """
+        return (
+            self.return_id
+            and self.location_id.usage in ["supplier", "transit"]
+            and self.return_id._is_intercompany_delivery()
+        )
+
+    def _is_intercompany_return_delivery(self):
+        """
+        Check if the picking is an inter-company return delivery.
+        :return: bool
+        """
+        return (
+            self.return_id
+            and self.location_dest_id.usage in ["customer", "transit"]
+            and self.return_id._is_intercompany_reception()
         )

--- a/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
+++ b/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
@@ -336,41 +336,12 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         so_picking_id = sale.picking_ids
 
         so_move = so_picking_id.move_ids
+        move_line_vals = so_move._prepare_move_line_vals()
         so_move.move_line_ids = [
             Command.clear(),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_1.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_2.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_3.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
         ]
         so_picking_id.button_validate()
 
@@ -420,19 +391,7 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         self.company_b.sync_picking = True
         # Set inter-company locations on partners
         interco_location = self.env.ref("stock.stock_location_inter_company")
-        self.partner_company_b.with_company(self.company_a).write(
-            {
-                "property_stock_customer": interco_location.id,
-                "property_stock_supplier": interco_location.id,
-            }
-        )
-        self.partner_company_a.with_company(self.company_b).write(
-            {
-                "property_stock_customer": interco_location.id,
-                "property_stock_supplier": interco_location.id,
-            }
-        )
-
+        self.company_a._set_per_company_inter_company_locations(interco_location)
         purchase = self._create_purchase_order(
             self.partner_company_b, self.stockable_product_serial
         )
@@ -443,41 +402,12 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         so_picking_id = sale.picking_ids
 
         so_move = so_picking_id.move_ids
+        move_line_vals = so_move._prepare_move_line_vals()
         so_move.move_line_ids = [
             Command.clear(),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_1.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_2.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_3.id,
-                    "picking_id": so_picking_id.id,
-                },
-            ),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
         ]
         so_picking_id.button_validate()
         self.assertEqual(so_picking_id.location_id.usage, "internal")
@@ -721,18 +651,7 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         self.warehouse_c.delivery_steps = "pick_ship"
         # Set inter-company locations on partners
         interco_location = self.env.ref("stock.stock_location_inter_company")
-        self.partner_company_b.with_company(self.company_a).write(
-            {
-                "property_stock_customer": interco_location.id,
-                "property_stock_supplier": interco_location.id,
-            }
-        )
-        self.partner_company_a.with_company(self.company_b).write(
-            {
-                "property_stock_customer": interco_location.id,
-                "property_stock_supplier": interco_location.id,
-            }
-        )
+        self.company_a._set_per_company_inter_company_locations(interco_location)
         purchase = self._create_purchase_order(
             self.partner_company_b, self.stockable_product_serial
         )
@@ -751,41 +670,12 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         # validate the SO internal picking
         so_internal_pick = sale.picking_ids
         so_move = so_internal_pick.move_ids
+        move_line_vals = so_move._prepare_move_line_vals()
         so_move.move_line_ids = [
             Command.clear(),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_1.id,
-                    "picking_id": so_internal_pick.id,
-                },
-            ),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_2.id,
-                    "picking_id": so_internal_pick.id,
-                },
-            ),
-            Command.create(
-                {
-                    "location_id": so_move.location_id.id,
-                    "location_dest_id": so_move.location_dest_id.id,
-                    "product_id": self.stockable_product_serial.id,
-                    "product_uom_id": self.stockable_product_serial.uom_id.id,
-                    "quantity": 1,
-                    "lot_id": self.serial_3.id,
-                    "picking_id": so_internal_pick.id,
-                },
-            ),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
         ]
         so_internal_pick.with_user(self.user_company_b).button_validate()
         self.assertEqual(so_internal_pick.state, "done")
@@ -858,3 +748,149 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         sale = self._approve_po()
         # NEW behavior: matching warehouse must be used
         self.assertEqual(sale.warehouse_id, partner_wh)
+
+    def test_full_return_with_lot(self):
+        """
+        Test that the lot is synchronized on the moves
+        when using inter-company transit locations
+        company B: Sale picking from Stock to Transit Location
+        company A: Purchase picking from Transit Location to Stock
+        Returned the picking
+        """
+        self.company_a.sync_picking = True
+        self.company_b.sync_picking = True
+        # Set inter-company locations on partners
+        interco_location = self.env.ref("stock.stock_location_inter_company")
+        self.company_a._set_per_company_inter_company_locations(interco_location)
+        purchase = self._create_purchase_order(
+            self.partner_company_b, self.stockable_product_serial
+        )
+        sale = self._approve_po(purchase)
+        po_picking = purchase.picking_ids
+        so_picking = sale.picking_ids
+        so_move = so_picking.move_ids
+        move_line_vals = so_move._prepare_move_line_vals()
+        so_move.move_line_ids = [
+            Command.clear(),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
+        ]
+        so_picking.button_validate()
+        self.assertEqual(so_picking.location_id.usage, "internal")
+        self.assertEqual(so_picking.location_dest_id.usage, "transit")
+        self.assertEqual(po_picking.location_id.usage, "transit")
+        self.assertEqual(po_picking.location_dest_id.usage, "internal")
+        so_lots = so_picking.move_line_ids.lot_id
+        po_lots = po_picking.move_line_ids.lot_id
+        self.assertEqual(so_lots, po_lots)
+        self.assertFalse(so_lots.company_id)
+        return_wizard = self.env["stock.return.picking"].create(
+            {"picking_id": so_picking.id}
+        )
+        action = return_wizard.action_create_returns_all()
+        so_return = self.env["stock.picking"].browse(action["res_id"])
+        po_return = po_picking.return_ids
+        self.assertEqual(len(purchase.picking_ids), 2)
+        self.assertEqual(len(sale.picking_ids), 2)
+        self.assertEqual(po_picking.return_count, 1)
+        self.assertEqual(so_picking.return_count, 1)
+        self.assertEqual(po_return.state, "assigned")
+        self.assertEqual(so_return.state, "assigned")
+        so_return.button_validate()
+        self.assertEqual(po_return.state, "done")
+        self.assertEqual(so_return.state, "done")
+        so_return_lots = so_return.move_line_ids.lot_id
+        po_return_lots = po_return.move_line_ids.lot_id
+        self.assertEqual(so_return_lots, po_return_lots)
+        self.assertEqual(so_return_lots, so_lots)
+
+    def test_partial_return_with_lot(self):
+        """
+        Test that the lot is synchronized on the moves
+        when using inter-company transit locations
+        company B: Sale picking from Stock to Transit Location
+        company A: Purchase picking from Transit Location to Stock
+        Returned the picking
+        """
+        self.company_a.sync_picking = True
+        self.company_b.sync_picking = True
+        # Set inter-company locations on partners
+        interco_location = self.env.ref("stock.stock_location_inter_company")
+        self.company_a._set_per_company_inter_company_locations(interco_location)
+        purchase = self._create_purchase_order(
+            self.partner_company_b, self.stockable_product_serial
+        )
+        sale = self._approve_po(purchase)
+        po_picking = purchase.picking_ids
+        so_picking = sale.picking_ids
+        so_move = so_picking.move_ids
+        move_line_vals = so_move._prepare_move_line_vals()
+        so_move.move_line_ids = [
+            Command.clear(),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
+        ]
+        so_picking.button_validate()
+        self.assertEqual(so_picking.location_id.usage, "internal")
+        self.assertEqual(so_picking.location_dest_id.usage, "transit")
+        self.assertEqual(po_picking.location_id.usage, "transit")
+        self.assertEqual(po_picking.location_dest_id.usage, "internal")
+        so_lots = so_picking.move_line_ids.lot_id
+        po_lots = po_picking.move_line_ids.lot_id
+        self.assertEqual(so_lots, po_lots)
+        self.assertFalse(so_lots.company_id)
+        # Generate a first return for 2 products, and validate it
+        return_wizard = self.env["stock.return.picking"].create(
+            {"picking_id": so_picking.id}
+        )
+        return_wizard.product_return_moves.quantity = 2
+        action = return_wizard.action_create_returns()
+        so_return = self.env["stock.picking"].browse(action["res_id"])
+        po_return = po_picking.return_ids
+        self.assertEqual(len(purchase.picking_ids), 2)
+        self.assertEqual(len(sale.picking_ids), 2)
+        self.assertEqual(po_picking.return_count, 1)
+        self.assertEqual(so_picking.return_count, 1)
+        self.assertEqual(po_return.state, "assigned")
+        self.assertEqual(so_return.state, "assigned")
+        move_line_vals = so_return.move_ids._prepare_move_line_vals()
+        so_return.move_ids.move_line_ids = [
+            Command.clear(),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
+        ]
+        so_return.button_validate()
+        self.assertEqual(po_return.state, "done")
+        self.assertEqual(so_return.state, "done")
+        so_return_lots = so_return.move_line_ids.lot_id
+        po_return_lots = po_return.move_line_ids.lot_id
+        self.assertEqual(so_return_lots, po_return_lots)
+        self.assertNotIn(self.serial_3, so_return_lots)
+        # Generate a second return
+        return_wizard = self.env["stock.return.picking"].create(
+            {"picking_id": so_picking.id}
+        )
+        return_wizard.product_return_moves.quantity = 1
+        action = return_wizard.action_create_returns()
+        so_return2 = self.env["stock.picking"].browse(action["res_id"])
+        po_return2 = po_picking.return_ids - po_return
+        self.assertEqual(len(purchase.picking_ids), 3)
+        self.assertEqual(len(sale.picking_ids), 3)
+        self.assertEqual(po_picking.return_count, 2)
+        self.assertEqual(so_picking.return_count, 2)
+        self.assertEqual(po_return2.state, "assigned")
+        self.assertEqual(so_return2.state, "assigned")
+        move_line_vals = so_return2.move_ids._prepare_move_line_vals()
+        so_return2.move_ids.move_line_ids = [
+            Command.clear(),
+            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
+        ]
+        so_return2.button_validate()
+        self.assertEqual(po_return2.state, "done")
+        self.assertEqual(so_return2.state, "done")
+        so_return2_lots = so_return2.move_line_ids.lot_id
+        po_return2_lots = po_return2.move_line_ids.lot_id
+        self.assertEqual(so_return2_lots, po_return2_lots)
+        self.assertEqual(self.serial_3, so_return2_lots)

--- a/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
+++ b/purchase_sale_stock_inter_company/tests/test_inter_company_purchase_sale_stock.py
@@ -6,6 +6,7 @@
 
 from odoo import Command
 from odoo.exceptions import UserError
+from odoo.tools import mute_logger
 
 from odoo.addons.purchase_sale_inter_company.tests import (
     test_inter_company_purchase_sale as test_icps,
@@ -749,6 +750,7 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         # NEW behavior: matching warehouse must be used
         self.assertEqual(sale.warehouse_id, partner_wh)
 
+    @mute_logger("odoo.models.unlink")
     def test_full_return_with_lot(self):
         """
         Test that the lot is synchronized on the moves
@@ -805,6 +807,7 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         self.assertEqual(so_return_lots, po_return_lots)
         self.assertEqual(so_return_lots, so_lots)
 
+    @mute_logger("odoo.models.unlink")
     def test_partial_return_with_lot(self):
         """
         Test that the lot is synchronized on the moves
@@ -845,7 +848,12 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         return_wizard = self.env["stock.return.picking"].create(
             {"picking_id": so_picking.id}
         )
-        return_wizard.product_return_moves.quantity = 2
+        if "lot_id" in return_wizard.product_return_moves._fields:
+            return_wizard.product_return_moves.filtered(
+                lambda x: x.lot_id == self.serial_3
+            ).unlink()
+        else:
+            return_wizard.product_return_moves.quantity = 2
         action = return_wizard.action_create_returns()
         so_return = self.env["stock.picking"].browse(action["res_id"])
         po_return = po_picking.return_ids
@@ -855,12 +863,17 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         self.assertEqual(so_picking.return_count, 1)
         self.assertEqual(po_return.state, "assigned")
         self.assertEqual(so_return.state, "assigned")
-        move_line_vals = so_return.move_ids._prepare_move_line_vals()
-        so_return.move_ids.move_line_ids = [
-            Command.clear(),
-            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)),
-            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)),
-        ]
+        if "restrict_lot_id" not in so_return.move_ids._fields:
+            move_line_vals = so_return.move_ids._prepare_move_line_vals()
+            so_return.move_ids.move_line_ids = [
+                Command.clear(),
+                Command.create(
+                    dict(move_line_vals, quantity=1, lot_id=self.serial_1.id)
+                ),
+                Command.create(
+                    dict(move_line_vals, quantity=1, lot_id=self.serial_2.id)
+                ),
+            ]
         so_return.button_validate()
         self.assertEqual(po_return.state, "done")
         self.assertEqual(so_return.state, "done")
@@ -872,7 +885,12 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         return_wizard = self.env["stock.return.picking"].create(
             {"picking_id": so_picking.id}
         )
-        return_wizard.product_return_moves.quantity = 1
+        if "lot_id" in return_wizard.product_return_moves._fields:
+            return_wizard.product_return_moves.filtered(
+                lambda x: x.lot_id != self.serial_3
+            ).unlink()
+        else:
+            return_wizard.product_return_moves.quantity = 1
         action = return_wizard.action_create_returns()
         so_return2 = self.env["stock.picking"].browse(action["res_id"])
         po_return2 = po_picking.return_ids - po_return
@@ -882,11 +900,14 @@ class TestPurchaseSaleStockInterCompany(TestPurchaseSaleInterCompany):
         self.assertEqual(so_picking.return_count, 2)
         self.assertEqual(po_return2.state, "assigned")
         self.assertEqual(so_return2.state, "assigned")
-        move_line_vals = so_return2.move_ids._prepare_move_line_vals()
-        so_return2.move_ids.move_line_ids = [
-            Command.clear(),
-            Command.create(dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)),
-        ]
+        if "restrict_lot_id" not in so_return.move_ids._fields:
+            move_line_vals = so_return2.move_ids._prepare_move_line_vals()
+            so_return2.move_ids.move_line_ids = [
+                Command.clear(),
+                Command.create(
+                    dict(move_line_vals, quantity=1, lot_id=self.serial_3.id)
+                ),
+            ]
         so_return2.button_validate()
         self.assertEqual(po_return2.state, "done")
         self.assertEqual(so_return2.state, "done")

--- a/purchase_sale_stock_inter_company/wizard/__init__.py
+++ b/purchase_sale_stock_inter_company/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_return_picking

--- a/purchase_sale_stock_inter_company/wizard/stock_return_picking.py
+++ b/purchase_sale_stock_inter_company/wizard/stock_return_picking.py
@@ -31,9 +31,15 @@ class ReturnPicking(models.TransientModel):
             .with_company(dest_company)
             .create(vals)
         )
-        exclude_moves = return_wizard.product_return_moves.filtered(
-            lambda line: line.product_id not in self.product_return_moves.product_id
-        )
+        # stock_picking_return_lot compatibility
+        if "lot_id" in return_wizard.product_return_moves._fields:
+            exclude_moves = return_wizard.product_return_moves.filtered(
+                lambda line: line.lot_id not in self.product_return_moves.lot_id
+            )
+        else:
+            exclude_moves = return_wizard.product_return_moves.filtered(
+                lambda line: line.product_id not in self.product_return_moves.product_id
+            )
         return_wizard.product_return_moves = [
             Command.unlink(prm.id) for prm in exclude_moves
         ]
@@ -42,5 +48,10 @@ class ReturnPicking(models.TransientModel):
                 lambda line, wizard_line=wizard_line: line.product_id
                 == wizard_line.product_id
             )
+            # stock_picking_return_lot compatibility
+            if "lot_id" in wizard_line._fields:
+                dest_line = dest_line.filtered(
+                    lambda x, wizard_line=wizard_line: x.lot_id == wizard_line.lot_id
+                )
             dest_line.write({"quantity": wizard_line.quantity})
         return return_wizard

--- a/purchase_sale_stock_inter_company/wizard/stock_return_picking.py
+++ b/purchase_sale_stock_inter_company/wizard/stock_return_picking.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Tecnativa - Carlos Lopez
+
+from odoo import Command, models
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = "stock.return.picking"
+
+    def _create_return(self):
+        new_picking = super()._create_return()
+        if self._should_create_intercompany_return():
+            return_wizard = self._create_intercompany_return_wizard(new_picking)
+            return_wizard.with_context(skip_create_returns=True)._create_return()
+        return new_picking
+
+    def _should_create_intercompany_return(self):
+        return self.picking_id._is_intercompany_delivery() and not self.env.context.get(
+            "skip_create_returns", False
+        )
+
+    def _create_intercompany_return_wizard(self, new_picking):
+        intercompany_picking = self.picking_id.intercompany_picking_id
+        dest_company = intercompany_picking.sudo().company_id
+        intercompany_user = dest_company.intercompany_sale_user_id
+        intercompany_picking = intercompany_picking.with_user(intercompany_user)
+        vals = {"picking_id": intercompany_picking.id}
+        return_wizard = (
+            self.env["stock.return.picking"]
+            .with_context(active_id=intercompany_picking.id)
+            .with_user(intercompany_user)
+            .with_company(dest_company)
+            .create(vals)
+        )
+        exclude_moves = return_wizard.product_return_moves.filtered(
+            lambda line: line.product_id not in self.product_return_moves.product_id
+        )
+        return_wizard.product_return_moves = [
+            Command.unlink(prm.id) for prm in exclude_moves
+        ]
+        for wizard_line in self.product_return_moves:
+            dest_line = return_wizard.product_return_moves.filtered(
+                lambda line, wizard_line=wizard_line: line.product_id
+                == wizard_line.product_id
+            )
+            dest_line.write({"quantity": wizard_line.quantity})
+        return return_wizard


### PR DESCRIPTION

In this case, the return will be performed by the company that performed the delivery.

TT63075
@Tecnativa @pedrobaeza @sergio-teruel @carlosdauden @victoralmau @christian-ramos-tecnativa @metaminux could you please review this?