### PR TITLE
[18.0][FIX] purchase_sale_stock_inter_company: skip cancelled moves when syncing pickings

### DIFF
--- a/purchase_sale_stock_inter_company/models/stock_picking.py
+++ b/purchase_sale_stock_inter_company/models/stock_picking.py
@@ -97,7 +97,7 @@ class StockPicking(models.Model):
             dest_picking = self.intercompany_picking_id.with_user(
                 intercompany_user
             ).with_company(dest_company)
-            for move in self.move_ids:
+            for move in self.move_ids.filtered(lambda m: m.state != "cancel"):
                 move_lines = move.move_line_ids.filtered(lambda x: x.quantity > 0)
                 # To identify the correct move to write to,
                 # use both the SO-PO link and the intercompany_picking_id link


### PR DESCRIPTION
When validating an intercompany delivery, the sync logic iterated over all
stock moves, including cancelled ones.

This caused a validation error after replacing products in a picking: the
cancelled original move still tried to find a pending corresponding PO move,
but its purchase-side move had already been cancelled.

Skip cancelled moves during the intercompany picking sync, so only active
delivery moves propagate quantities/lots to the destination receipt.

cc @Tecnativa TT63574

ping @carlos-lopez-tecnativa @carlosdauden @victoralmau 