### PR TITLE
[FW][FIX] purchase_sale_inter_company: take into account sale order discounts

### DIFF
--- a/purchase_sale_inter_company/models/sale_order_line.py
+++ b/purchase_sale_inter_company/models/sale_order_line.py
@@ -22,10 +22,11 @@ class SaleOrderLine(models.Model):
         of the sale order line to the price unit
         of the purchase order line in case of intercompany sale.
         It takes into account the tax inclusion/exclusion
-        of both the sale order line and the purchase order line.
+        of both the sale order line and the purchase order line,
+        as well as the sale order line discount.
         """
         dest_taxes = self.auto_purchase_line_id.taxes_id
-        price_unit = self.price_unit
+        price_unit = self.price_unit * (1 - self.discount / 100)
         base_line = self._prepare_base_line_for_taxes_computation(quantity=1)
         self.env["account.tax"]._add_tax_details_in_base_line(
             base_line, self.company_id

--- a/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
+++ b/purchase_sale_inter_company/tests/test_inter_company_purchase_sale.py
@@ -223,6 +223,14 @@ class TestPurchaseSaleInterCompany(TestAccountInvoiceInterCompanyBase):
         sale.action_confirm()
         self.assertEqual(self.purchase_company_a.order_line.price_unit, 10)
 
+    def test_so_change_price_with_discount(self):
+        self.company_b.sale_auto_validation = False
+        sale = self._approve_po()
+        sale.order_line.price_unit = 100
+        sale.order_line.discount = 10
+        sale.action_confirm()
+        self.assertEqual(self.purchase_company_a.order_line.price_unit, 90.0)
+
     def test_po_with_contact_as_partner(self):
         contact = self.env["res.partner"].create(
             {"name": "Test contact", "parent_id": self.partner_company_b.id}


### PR DESCRIPTION
Currently, when a sale order line has a discount, this discount is not taken into account when updating the purchase order line price. Instead the sale order line unit price is passed to the purchase line unit price, causing an error in the valuation.

Unlike the 17.0/19.0 ports, 18.0 already refactored the price sync into _sync_price_unit_to_intercompany_purchase_line (which also handles cross-company tax include/exclude). That method already serves as the inheritable override point, so the discount is folded into it rather than introducing a separate method. The tax-crossing branches use raw_total_*_currency, which already account for the discount, so only the base case needed the change.