### PR TITLE
[19.0][FIX] base_multi_company: initialize company on create

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -93,6 +93,14 @@ class MultiCompanyAbstract(models.AbstractModel):
     def create(self, vals_list):
         """Discard changes in company_id field if company_ids has been given."""
         for vals in vals_list:
+            # Avoid triggering the inverse write of company_id after creating a record.
+            # The intermediate record has no company_ids yet, which can make
+            # company-dependent record rules reject the write for users creating
+            # products.
+            if "company_id" in vals and "company_ids" not in vals:
+                company_id = vals.pop("company_id")
+                if company_id:
+                    vals["company_ids"] = [fields.Command.link(company_id)]
             self._multicompany_patch_vals(vals)
         return super().create(vals_list)
 

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -225,6 +225,16 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         # Check if all companies have been added
         self.assertEqual(tester.sudo().company_ids, companies)
 
+    def test_company_id_only_create(self):
+        """Test object creation with only company_id."""
+        tester = self.test_model.create(
+            {
+                "name": "Company ID Tester",
+                "company_id": self.company_1.id,
+            }
+        )
+        self.assertEqual(tester.sudo().company_ids, self.company_1)
+
     def test_company_id_create_false(self):
         """
         Test a creation with only company_id == False


### PR DESCRIPTION
Avoid triggering the inverse write of company_id after creating a record. The intermediate record has no company_ids yet, which can make company-dependent record rules reject the write for users creating products.

cc @moduon MT-15413

please take a look @EmilioPascual @yajo 