### PR TITLE
[18.0][FIX] partner_multi_company: Prevent cache pollution when changing company_ids on parent partner

### DIFF
--- a/partner_multi_company/models/res_partner.py
+++ b/partner_multi_company/models/res_partner.py
@@ -32,6 +32,17 @@ class ResPartner(models.Model):
         commercial_fields += ["company_ids"]
         return commercial_fields
 
+    def _children_sync(self, values):
+        if "company_ids" in values:
+            # When the transaction is performed in sudo mode,
+            # see https://github.com/odoo/odoo/blob/629a563148452091bd1af9267596859b140350bb/odoo/addons/base/models/res_partner.py#L689
+            # the cache becomes inconsistent for the many2many field,
+            # and the child partners are not updated with the new company_ids value.
+            # Instead, they retain the previous value.
+            # Therefore, we need to invalidate the cache to force the update.
+            self.invalidate_recordset(["company_ids"], True)
+        return super()._children_sync(values)
+
     @api.model
     def _amend_company_id(self, vals):
         if "company_ids" in vals:

--- a/partner_multi_company/tests/test_partner_multi_company.py
+++ b/partner_multi_company/tests/test_partner_multi_company.py
@@ -240,6 +240,39 @@ class TestPartnerMultiCompany(common.TransactionCase):
             self.partner_company_both.company_ids,
         )
 
+    def test_commercial_fields_to_children(self):
+        """Test that company_ids are correctly propagated to child partners
+        when the parent is modified in sudo mode, to avoid cache pollution."""
+        self.user_company_1.company_ids = (self.company_1 + self.company_2).ids
+        child = self.env["res.partner"].create(
+            [{"name": "Child test", "parent_id": self.partner_company_both.id}]
+        )
+        # Remove the sudo mode by changing the user
+        self.assertTrue(self.partner_company_both.env.su)
+        partner_company_both = self.partner_company_both.with_user(self.user_company_1)
+        self.assertFalse(partner_company_both.env.su)
+        # Check that the original partner is in sudo mode
+        self.assertTrue(self.partner_company_both.env.su)
+        self.assertEqual(len(partner_company_both.company_ids), 2)
+        self.assertEqual(len(partner_company_both.sudo().company_ids), 2)
+        self.assertEqual(len(self.partner_company_both.company_ids), 2)
+        partner_company_both.company_ids = [Command.unlink(self.company_1.id)]
+        self.assertEqual(len(partner_company_both.company_ids), 1)
+        self.assertEqual(len(partner_company_both.sudo().company_ids), 1)
+        self.assertEqual(len(self.partner_company_both.company_ids), 1)
+        self.assertEqual(
+            child.company_ids,
+            partner_company_both.company_ids,
+        )
+        partner_company_both.company_ids = [Command.link(self.company_1.id)]
+        self.assertEqual(len(partner_company_both.company_ids), 2)
+        self.assertEqual(len(partner_company_both.sudo().company_ids), 2)
+        self.assertEqual(len(self.partner_company_both.company_ids), 2)
+        self.assertEqual(
+            child.company_ids,
+            partner_company_both.company_ids,
+        )
+
     def test_avoid_updating_company_ids_in_global_partners(self):
         self.user_company_1.write({"company_ids": [Command.link(self.company_2.id)]})
         user_partner = self.user_company_1.partner_id


### PR DESCRIPTION
FWD-Port of https://github.com/OCA/multi-company/pull/1037
Before this fix, modifying the `company_ids` field on a parent partner and propagating the change to its children caused cache pollution. Children would incorrectly retain outdated company values.

**Steps to reproduce:**
1. Create a partner with 2 companies.
2. Create a child of that partner.
3. Remove a company from the parent — the child still preserves the old companies.
4. Add a new company to the parent — the child still preserves the old companies.

**After this commit:**
The companies on the children are now synchronized correctly with the parent.

TT63857
@Tecnativa @pedrobaeza @christian-ramos-tecnativa @pilarvargas-tecnativa @victoralmau could you please review this?