### PR TITLE
[19.0][FIX] base_multi_company: handle non-stored company_id in SQL clauses

### DIFF
--- a/base_multi_company/models/multi_company_abstract.py
+++ b/base_multi_company/models/multi_company_abstract.py
@@ -2,8 +2,14 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+import logging
+
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 from odoo.orm.identifiers import NewId
+from odoo.tools import SQL
+
+_logger = logging.getLogger(__name__)
 
 
 class MultiCompanyAbstract(models.AbstractModel):
@@ -68,6 +74,41 @@ class MultiCompanyAbstract(models.AbstractModel):
             # We need to workaround an ORM issue to find records with no company
             domain = ["|", ("company_ids", new_op, False)] + domain
         return domain
+
+    def _order_field_to_sql(self, alias, field_name, direction, nulls, query):
+        """Skip ``company_id`` in ORDER BY instead of raising."""
+        fname = field_name.split(":", 1)[0].split(".", 1)[0]
+        field = self._fields.get(fname)
+        if fname == "company_id" and field is not None and not field.store:
+            _logger.debug(
+                "%s: ignoring non-stored company_id in ORDER BY term %r.",
+                self._name,
+                field_name,
+            )
+            return SQL()
+        return super()._order_field_to_sql(alias, field_name, direction, nulls, query)
+
+    def _read_group_groupby(self, alias, groupby_spec, query):
+        """Group on ``company_ids`` when asked to group on ``company_id``."""
+        fname = groupby_spec.split(":", 1)[0].split(".", 1)[0]
+        field = self._fields.get(fname)
+        if fname == "company_id" and field is not None and not field.store:
+            if groupby_spec != "company_id":
+                raise UserError(
+                    self.env._(
+                        "Grouping by %(spec)s is not supported on %(model)s "
+                        "because its Company field is computed from Companies. "
+                        "Group by Companies instead.",
+                        spec=groupby_spec,
+                        model=self._name,
+                    )
+                )
+            _logger.debug(
+                "%s: grouping on company_ids instead of the non-stored company_id.",
+                self._name,
+            )
+            return super()._read_group_groupby(alias, "company_ids", query)
+        return super()._read_group_groupby(alias, groupby_spec, query)
 
     def _multicompany_patch_vals(self, vals):
         """Patch vals to remove company_id and company_ids duplicity."""

--- a/base_multi_company/tests/test_multi_company_abstract.py
+++ b/base_multi_company/tests/test_multi_company_abstract.py
@@ -3,6 +3,7 @@
 # License LGPL-3 - See http://www.gnu.org/licenses/lgpl-3.0.html
 
 
+from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.orm.model_classes import add_to_registry
 from odoo.tests import common
@@ -404,3 +405,92 @@ class TestMultiCompanyAbstract(common.TransactionCase):
         # The resulting value must be a real integer or False, never a NewId
         if company_id:
             self.assertIsInstance(company_id.id, int)
+
+    def test_order_by_company_id(self):
+        """Sorting on the non-stored ``company_id`` must not raise."""
+        self.add_company(self.company_2)
+        records = self.test_model.search([], order="name DESC, company_id, id DESC")
+        self.assertIn(self.record_1, records)
+
+    def test_order_by_company_id_alone(self):
+        """A term that is only ``company_id`` degrades to no ordering."""
+        self.test_model.search([], order="company_id")
+
+    def test_order_by_company_id_path(self):
+        """``company_id.name`` needs the column too and must be skipped."""
+        self.test_model.search([], order="company_id.name")
+
+    def test_order_by_stored_field_still_reaches_the_database(self):
+        """Only ``company_id`` may be dropped, never a real column."""
+        record_2 = self.test_model.create({"name": "zzz order tester"})
+        record_3 = self.test_model.create({"name": "aaa order tester"})
+        records = self.test_model.search(
+            [("id", "in", (record_2 + record_3).ids)],
+            order="name ASC, company_id, id DESC",
+        )
+        self.assertEqual(records.ids, [record_3.id, record_2.id])
+
+    def test_read_group_by_company_id(self):
+        """Grouping on ``company_id`` falls back to ``company_ids``."""
+        self.add_company(self.company_1)
+        self.add_company(self.company_2)
+        record_2 = self.test_model.create(
+            {
+                "name": "group tester",
+                "company_ids": [Command.set(self.company_2.ids)],
+            }
+        )
+        groups = self.test_model._read_group(
+            [("id", "in", (self.record_1 + record_2).ids)],
+            groupby=["company_id"],
+            aggregates=["__count"],
+        )
+        counts = {company.id: count for company, count in groups}
+        self.assertEqual(counts.get(self.company_1.id), 1)
+        self.assertEqual(counts.get(self.company_2.id), 2)
+
+    def test_read_group_by_company_id_returns_companies(self):
+        """The group key must still be a ``res.company`` recordset."""
+        self.add_company(self.company_2)
+        groups = self.test_model._read_group(
+            [("id", "=", self.record_1.id)],
+            groupby=["company_id"],
+            aggregates=["__count"],
+        )
+        self.assertEqual(len(groups), 1)
+        company, count = groups[0]
+        self.assertEqual(company, self.company_2)
+        self.assertEqual(count, 1)
+
+    def test_read_group_by_company_id_without_company(self):
+        """Records shared across all companies group under an empty company."""
+        self.assertFalse(self.record_1.sudo().company_ids)
+        groups = self.test_model._read_group(
+            [("id", "=", self.record_1.id)],
+            groupby=["company_id"],
+            aggregates=["__count"],
+        )
+        self.assertEqual(len(groups), 1)
+        company, count = groups[0]
+        self.assertFalse(company)
+        self.assertEqual(count, 1)
+
+    def test_read_group_by_company_id_path_is_refused_cleanly(self):
+        """A many2one path cannot be redirected to a many2many."""
+        with self.assertRaises(UserError):
+            self.test_model._read_group(
+                [],
+                groupby=["company_id.name"],
+                aggregates=["__count"],
+            )
+
+    def test_read_group_by_stored_field_is_untouched(self):
+        """Grouping on anything else must behave normally."""
+        self.test_model.create({"name": "test"})
+        groups = self.test_model._read_group(
+            [("name", "=", "test")],
+            groupby=["name"],
+            aggregates=["__count"],
+        )
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], "test")


### PR DESCRIPTION
Fixes #993 for V19.

Problem

multi.company.abstract makes company_id non-stored on purpose: it depends on self.env.company, and a stored column cannot be context-dependent.
The method _search_company_id already handles the consequence for domains. ORDER BY and GROUP BY are the same class of problem, still unhandled, and both raise ValueError: Cannot convert <model>.company_id to SQL because it is not stored.

Steps to reproduce

Functionally: install partner_multi_company + account_peppol and receive one Peppol document. The bill arrives with its XML attachment and nothing else, because account_peppol._peppol_import_invoice catches the ValueError with a bare except Exception and still acknowledges the document to the proxy.

Backports

The bug is present on 16.0, 17.0, 18.0 and 19.0. The hooks are not stable across versions, so backports need adjusting.
