### PR TITLE
[18.0][IMP] account_invoice_inter_company: Set journal and company explicitly

### DIFF
--- a/account_invoice_inter_company/models/account_move.py
+++ b/account_invoice_inter_company/models/account_move.py
@@ -142,6 +142,7 @@ class AccountMove(models.Model):
                     "dest_company_id": dest_company.id,
                 }
             )
+        return dest_journal
 
     def _inter_company_create_invoice(self, dest_company):
         """create an invoice for the given company : it will copy
@@ -242,10 +243,12 @@ class AccountMove(models.Model):
         self.ensure_one()
         self = self.with_context(**clean_context(self.env.context))
         # check if the journal is define in dest company
-        self._check_dest_journal(dest_company)
+        dest_journal = self._check_dest_journal(dest_company)
         vals = {
             "move_type": self._get_destination_invoice_type(),
             "partner_id": self.company_id.partner_id.id,
+            "company_id": dest_company.id,
+            "journal_id": dest_journal.id,
             "ref": self.name,
             "payment_reference": self.payment_reference,
             "invoice_date": self.invoice_date,


### PR DESCRIPTION
In strange cases, when a customer invoice is validated and the system tries to create a vendor bill, the user gets the error: `Cannot create a purchase document in a non-purchase journal`

Before this commit, Odoo computed the company and journal. Instead, we set these fields explicitly to prevent them from being recomputed.

TT64262
@Tecnativa @pedrobaeza could you please review this?