### PR TITLE
[18.0][FIX] product_multi_company: keep company_ids on variant write

### DIFF
--- a/product_multi_company/models/__init__.py
+++ b/product_multi_company/models/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import product_template
+from . import product_product

--- a/product_multi_company/models/product_product.py
+++ b/product_multi_company/models/product_product.py
@@ -1,0 +1,24 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # `company_id` and `company_ids` are related fields to
+        # `product.template`, which discards `company_id` on write/create
+        # when `company_ids` is also given, to prevent its `inverse` from
+        # overwriting `company_ids` (see
+        # `MultiCompanyAbstract._multicompany_patch_vals`). `product.product`
+        # doesn't inherit that mixin, so replicate the same protection here.
+        for vals in vals_list:
+            self.env["product.template"]._multicompany_patch_vals(vals)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        self.env["product.template"]._multicompany_patch_vals(vals)
+        return super().write(vals)

--- a/product_multi_company/tests/test_product_multi_company.py
+++ b/product_multi_company/tests/test_product_multi_company.py
@@ -114,6 +114,29 @@ class TestProductMultiCompany(ProductMultiCompanyCommon, common.TransactionCase)
             self.product_company_both.product_tmpl_id.company_ids,
         )
 
+    def test_product_variant_write_company_id_and_company_ids(self):
+        # The product form (and the variant form, which reuses the same
+        # arch through view inheritance) includes an invisible `company_id`
+        # field in the header, used as a trick to be able to set that field
+        # from the view. When the web client saves, it sends both
+        # `company_id` and `company_ids` in the same `write` call.
+        # `product.template.write` protects against this collision through
+        # `_multicompany_patch_vals`, discarding the redundant `company_id`
+        # so its inverse doesn't overwrite `company_ids`. `product.product`
+        # doesn't have this protection, so a write coming from the variant
+        # form silently reverts `company_ids` to a single company.
+        product = self.product_company_1.product_variant_id
+        product.write(
+            {
+                "company_ids": [(4, self.company_2.id)],
+                "company_id": self.company_1.id,
+            }
+        )
+        self.assertEqual(
+            product.company_ids,
+            self.company_1 + self.company_2,
+        )
+
     def test_search_product(self):
         """Products with no company are shared across companies but we need to convert
         those queries with an or operator"""


### PR DESCRIPTION
The product form's header includes an invisible `company_id` field, used as a trick to be able to set that field from the view. When the web client saves, it sends both `company_id` and `company_ids` in the same write call.

`product.template.write()` already protects against this collision through `_multicompany_patch_vals`, discarding the redundant `company_id` so its inverse doesn't overwrite `company_ids`.

`product.product` doesn't inherit `multi.company.abstract` and lacks this protection, even though it exposes the same fields (related to the template). Saving from the variant form (e.g. reached from the MRP Area Parameters view) silently reverted `company_ids` to a single company.